### PR TITLE
Hiero SDK update

### DIFF
--- a/hiero-enterprise-base/pom.xml
+++ b/hiero-enterprise-base/pom.xml
@@ -54,12 +54,7 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-okhttp</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-inprocess</artifactId>
+      <artifactId>grpc-netty-shaded</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hiero-enterprise-base/src/main/java/module-info.java
+++ b/hiero-enterprise-base/src/main/java/module-info.java
@@ -19,7 +19,7 @@ module com.openelements.hiero.base {
   provides com.openelements.hiero.base.config.NetworkSettingsProvider with
       com.openelements.hiero.base.config.hedera.HederaNetworkSettingsProvider;
 
-  requires transitive sdk; // Hedera SDK
+  requires transitive com.hedera.hashgraph.sdk; // Hedera SDK
   requires org.slf4j;
   requires com.google.protobuf; // TODO: We should not have the need to use it
   requires static org.jspecify;

--- a/hiero-enterprise-microprofile-sample/pom.xml
+++ b/hiero-enterprise-microprofile-sample/pom.xml
@@ -32,11 +32,7 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-okhttp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-inprocess</artifactId>
+      <artifactId>grpc-netty-shaded</artifactId>
     </dependency>
   </dependencies>
 

--- a/hiero-enterprise-microprofile/pom.xml
+++ b/hiero-enterprise-microprofile/pom.xml
@@ -64,12 +64,7 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-okhttp</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-inprocess</artifactId>
+      <artifactId>grpc-netty-shaded</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hiero-enterprise-spring-sample/pom.xml
+++ b/hiero-enterprise-spring-sample/pom.xml
@@ -36,11 +36,7 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-okhttp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-inprocess</artifactId>
+      <artifactId>grpc-netty-shaded</artifactId>
     </dependency>
   </dependencies>
 

--- a/hiero-enterprise-spring/pom.xml
+++ b/hiero-enterprise-spring/pom.xml
@@ -55,12 +55,7 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-okhttp</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-inprocess</artifactId>
+      <artifactId>grpc-netty-shaded</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hiero-enterprise-spring/src/test/resources/application.properties
+++ b/hiero-enterprise-spring/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 spring.config.import=optional:file:.env[.properties]
-spring.hiero.accountId=${HEDERA_ACCOUNT_ID:0.0.4457570}
+spring.hiero.accountId=${HEDERA_ACCOUNT_ID}
 spring.hiero.privateKey=${HEDERA_PRIVATE_KEY}
 spring.hiero.network.name=${HEDERA_NETWORK:hedera-testnet}
 logging.level.com.openelements=DEBUG

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,11 @@
     <hedera.sdk-version>2.32.0</hedera.sdk-version>
     <grpc.version>1.58.0</grpc.version>
     <spring.version>6.1.8</spring.version>
-    <spring.boot.version>3.3.0</spring.boot.version>
+    <spring.boot.version>3.5.11</spring.boot.version>
     <jspecify.version>1.0.0</jspecify.version>
-    <dotenv.version>3.0.0</dotenv.version>
-    <junit.version>6.0.1</junit.version>
-    <slf4j.version>2.0.13</slf4j.version>
+    <dotenv.version>3.2.0</dotenv.version>
+    <junit.version>6.0.3</junit.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <helidon.version>4.1.4</helidon.version>
     <helidon.test.version>3.2.11</helidon.test.version>
     <jakarta.enterprise.version>3.0.1</jakarta.enterprise.version>
@@ -52,19 +52,19 @@
     <quarkus.version>3.17.2</quarkus.version>
     <google.auto.version>1.1.1</google.auto.version>
     <jboss-logging.version>3.6.1.Final</jboss-logging.version>
-    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
+    <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
+    <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+    <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
-    <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
-    <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
+    <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+    <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
     <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
     <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
-    <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.3.0</spotless-maven-plugin.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <hedera.sdk-version>2.32.0</hedera.sdk-version>
-    <grpc.version>1.58.0</grpc.version>
+    <hedera.sdk-version>2.68.0</hedera.sdk-version>
+    <grpc.version>1.79.0</grpc.version>
     <spring.version>6.1.8</spring.version>
     <spring.boot.version>3.5.11</spring.boot.version>
     <jspecify.version>1.0.0</jspecify.version>


### PR DESCRIPTION
This PR depends on https://github.com/hiero-ledger/hiero-sdk-java/pull/2649 - Without that fix Hiero SDK is problematic to use in a module based Java project

This pull request updates dependencies and refines configuration across several modules to ensure compatibility with newer versions of the Hedera SDK and gRPC, while also simplifying gRPC transport selection. The most significant changes are dependency version bumps, replacement of gRPC transport libraries, and minor improvements to configuration and module declarations.