### PR TITLE
docs: improve README quick-start and fix inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This project provides Java modules to interact with a [Hiero network](https://hi
 The project provides integrations to Spring Boot or Eclipse Microprofile (like Quarkus) for interacting with Hiero.
 This module is based on the [Hedera Java SDK](https://github.com/hashgraph/hedera-sdk-java)(will be migrated to Hiero Java SDK in near future) and provides a set of managed services to interact with a Hiero network.
 
+## Quick start
+
+- Use `hiero-enterprise-spring` for Spring Boot applications.
+- Use `hiero-enterprise-microprofile` for MicroProfile / Quarkus applications.
+- See the full guides in [`docs/`](docs/) (or the published docs on GitHub Pages).
+
 ## Spring Boot support
 
 To use this module, you need to add the following dependency to your project:
@@ -45,7 +51,7 @@ The operator account is used as the account that sends all transactions against 
 To use the module, you need to add the `@EnableHiero` annotation to your Spring Boot application class.
 
 ```java
-import com.open.elements.spring.hiero.EnableHiero;
+import org.hiero.spring.EnableHiero;
 
 @SpringBootApplication
 @EnableHiero
@@ -56,7 +62,7 @@ public class Application {
 }
 ```
  
-Once that is done you can for example autowire the `FileClient` class and call the methods to interact with a Hiero network.
+Once that is done you can autowire the `FileClient` class and call methods to interact with a Hiero network.
 
 ```java
 
@@ -80,9 +86,9 @@ For asynchronous operations, you can easily wrap calls by use the [`@Async` anno
 ### Hiero Spring Sample
 
 A sample application that uses the Hiero Spring module can be found in the `hiero-enterprise-spring-sample` module.
-The sample application is a simple Spring Boot application that reads has a REST endpoint at `localhost:8080/` and  shows the hbar balance of the account `0.0.100` on the Hedera testnet.
+The sample application is a simple Spring Boot application that exposes a REST endpoint at `localhost:8080/` and shows the hbar balance of the account `0.0.100` on the Hedera testnet.
 To use the application, you need to have created a Hedera testnet account at the [Hedera portal](https://portal.hedera.com/).
-The account information can be added to the `application.properties` file in the `hedera-spring-sample` module:
+The account information can be added to the `application.properties` file in the `hiero-enterprise-spring-sample` module:
 ```properties
 spring.hiero.accountId=0.0.3447271
 spring.hiero.privateKey=2130020100312346052b8104400304220420c236508c429395a8180b1230f436d389adc5afaa9145456783b57b2045c6cc37
@@ -118,7 +124,7 @@ To use this module, you need to add the following dependency to your project:
 ```
 
 The `hiero-enterprise-microprofile-sample` module contains a sample application that uses the Hiero Microprofile module.
-The sample application is a simple Quarkus application that reads has a REST endpoint at `localhost:8080/` and  shows
+The sample application is a simple Quarkus application that exposes a REST endpoint at `localhost:8080/` and shows
 the hbar balance of the account `0.0.100` on the Hedera testnet.
 For most of the part, the sample application is the same as the Spring Boot sample application.
 
@@ -146,7 +152,7 @@ Next to that the following low-level services are available:
 - `base.org.hiero.protocol.ProtocolLayerClient`: to interact with the Hiero protocol layer
 - `base.org.hiero.mirrornode.MirrorNodeClient`: to query the Hiero mirror node 
 
-## Built the project
+## Build the project
 
 The project is based on [Maven](https://maven.apache.org/).
 The Maven wrapper is used to build the project.
@@ -162,7 +168,7 @@ You need to provide the account id and the private key of an account that is use
 **If no account is provided, the tests will fail.**
 The most easy way to run the tests is to use the Hedera testnet network.
 To run the tests, you need to provide the account id and the "DER Encoded Private Key" of the "ECDSA" testnet account.
-That information can be provided as environemt variables:
+That information can be provided as environment variables:
  
 ```shell
 export HEDERA_ACCOUNT_ID=0.0.3447271
@@ -181,7 +187,7 @@ spring.hiero.privateKey=2130020100312346052b8104400304220420c236508c429395a8180b
 
 ### Create a release
 
-Currently there is no running release process and we work on setting uop everything to do releases under the hiero-ledger org.
+Currently there is no running release process and we are setting up releases under the `hiero-ledger` organization.
 
 ## Documentation
 


### PR DESCRIPTION
## Motivation

This PR improves the top-level documentation so developers can get started faster and avoid confusion from outdated or inaccurate examples.
It specifically targets clarity, correctness, and readability in the main `README.md` without changing runtime behavior.

---

## What was changed

### 1) Added a Quick Start section

* Introduced a short **Quick Start** block near the top of `README.md`.
* Clearly guides users on which module to choose:

  * `hiero-enterprise-spring` for **Spring Boot**
  * `hiero-enterprise-microprofile` for **MicroProfile / Quarkus**
* Added a pointer to detailed documentation in the `docs/` directory.

### 2) Fixed incorrect Spring import in usage example

* Updated the `@EnableHiero` import to:

  ```java
  import org.hiero.spring.EnableHiero;
  ```
* Ensures the README matches the actual package structure and prevents copy-paste errors.

### 3) Corrected Spring sample wording and module reference

* Improved clarity in the sample description (“exposes a REST endpoint…”).
* Fixed module naming to `hiero-enterprise-spring-sample` for consistency.

### 4) Improved MicroProfile sample wording

* Updated phrasing for better readability and consistency.
* Standardized wording (“exposes a REST endpoint…”).

### 5) Cleaned build/release documentation language

* Renamed section: **“Built the project” → “Build the project”**
* Fixed typo: `environemt` → `environment`
* Refined release process description for clarity and professionalism.

---

## Code changes

* No Java source code behavior changes were made.
* All updates are documentation-only in `README.md`.

---

## Testing / validation

* Documentation reviewed for structure, readability, and consistency.
* No automated tests were required since no functional code was modified.
