### PR TITLE
docs: improve MkDocs infrastructure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,8 +61,12 @@ jobs:
         run: mkdocs gh-deploy --force --strict
 
   # PR preview: build and deploy to .../pr/<number>/
+  # Skipped for fork PRs because GITHUB_TOKEN is read-only and cannot push to gh-pages.
   deploy-preview:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.action != 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,12 +6,15 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "requirements-docs.txt"
       - ".github/workflows/docs.yml"
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     branches: [main]
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "requirements-docs.txt"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -29,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Configure Git Credentials
         run: |
@@ -49,18 +54,20 @@ jobs:
           restore-keys: |
             mkdocs-material-
 
-      - name: Install MkDocs and Material
-        run: pip install mkdocs-material "pymdown-extensions"
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
 
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        run: mkdocs gh-deploy --force --strict
 
   # PR preview: build and deploy to .../pr/<number>/
   deploy-preview:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Configure Git Credentials
         run: |
@@ -81,8 +88,8 @@ jobs:
           restore-keys: |
             mkdocs-material-
 
-      - name: Install MkDocs and Material
-        run: pip install mkdocs-material "pymdown-extensions"
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
 
       - name: Build site
         run: mkdocs build --strict
@@ -100,9 +107,50 @@ jobs:
         with:
           script: |
             const url = `https://hiero-ledger.github.io/hiero-enterprise-java/pr/${{ github.event.pull_request.number }}/`;
-            github.rest.issues.createComment({
+            const body = `📖 **Docs preview** for this PR: ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `📖 **Docs preview** for this PR: ${url}`
             });
+            const botComment = comments.find(
+              (c) => c.user.type === 'Bot' && c.body.includes('Docs preview')
+            );
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+            }
+
+  # Clean up PR preview when PR is closed or merged
+  cleanup-preview:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+
+      - name: Remove PR preview directory
+        run: |
+          PR_DIR="pr/${{ github.event.pull_request.number }}"
+          if [ -d "$PR_DIR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git rm -rf "$PR_DIR"
+            git commit -m "docs: remove preview for PR #${{ github.event.pull_request.number }}"
+            git push
+          else
+            echo "No preview directory found for PR #${{ github.event.pull_request.number }}, nothing to clean up."
+          fi

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ The site is built with [MkDocs](https://www.mkdocs.org/) and the [Material for M
 From the repository root:
 
 ```bash
-pip install mkdocs-material "pymdown-extensions"
+pip install -r requirements-docs.txt
 mkdocs serve
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,23 +27,57 @@ theme:
         name: Switch to light mode
   features:
     - content.tabs.link
+    - content.code.copy
+    - content.code.annotate
     - navigation.tabs
     - navigation.sections
     - navigation.indexes
+    - navigation.top
+    - navigation.footer
+    - navigation.instant
+    - navigation.tracking
+    - search.suggest
+    - search.highlight
     - toc.integrate
 
 extra_css:
   - stylesheets/extra.css
 
+extra:
+  version:
+    provider: mike
+    default: latest
+
 plugins:
   - search
+  - git-revision-date-localized:
+      enable_creation_date: true
+      fallback_to_build_date: true
+  - minify:
+      minify_html: true
 
 markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.snippets
+  - pymdownx.keys
 
 nav:
   - Home: index.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+mkdocs-material==9.6.12
+pymdown-extensions>=10.14
+mkdocs-minify-plugin>=0.8.0,<1
+mkdocs-git-revision-date-localized-plugin>=1.4.0,<2


### PR DESCRIPTION
Closes #17

## Summary

- **Dependency pinning** — adds `requirements-docs.txt` pinning all docs Python packages (`mkdocs-material==9.6.12`, `pymdown-extensions`, `mkdocs-minify-plugin`, `mkdocs-git-revision-date-localized-plugin`) for reproducible builds
- **Expanded `mkdocs.yml`** — adds 8 theme features (code copy, nav footer/top, instant navigation, URL tracking, search suggestions/highlight), 11 markdown extensions (admonitions, tabbed content, TOC permalinks, syntax highlighting, collapsible details, snippets, keyboard keys, etc.), two new plugins (`git-revision-date-localized` with build-date fallback, `minify`), and `mike` version provider prep for when releases start
- **Workflow fixes** (`docs.yml`):
  - Production deploy now runs `mkdocs gh-deploy --force --strict` (was missing `--strict`)
  - `fetch-depth: 0` on both jobs for accurate "Last updated" dates from git history
  - Both jobs install from `requirements-docs.txt` instead of inline `pip install`
  - Added `requirements-docs.txt` to the `paths` trigger
  - PR preview bot comment is now deduplicated — updates existing comment instead of posting a new one on each push
  - `deploy-preview` guarded with `github.event.action != 'closed'` to avoid running on close events
  - New `cleanup-preview` job removes stale `pr/<N>/` directories from `gh-pages` when a PR is closed or merged
- **`docs/contributing.md`** — updated local install instructions to use `requirements-docs.txt`

## Test plan

- [ ] `pip install -r requirements-docs.txt && python -m mkdocs build --strict` passes locally (verified ✅)
- [ ] PR preview deploys correctly and only one bot comment appears per PR
- [ ] After merge, `pr/<N>/` directory is cleaned up from the `gh-pages` branch
- [ ] Production deploy runs with `--strict` and succeeds
- [ ] "Last updated" dates appear at the bottom of doc pages