### PR TITLE
fix: do not expose operator private key in logs or error messages

### DIFF
--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/TestConfigSource.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/TestConfigSource.java
@@ -48,7 +48,9 @@ public class TestConfigSource implements ConfigSource {
         .filter(e -> !e.getKey().equals("hiero.network.name"))
         .forEach(e -> properties.put(e.getKey(), e.getValue()));
 
-    properties.forEach((k, v) -> log.info("CONFIG: '" + k + "'->'" + v + "'"));
+    properties.forEach(
+        (k, v) ->
+            log.info("CONFIG: '" + k + "'->'" + ("hiero.privateKey".equals(k) ? "***" : v) + "'"));
   }
 
   @Override

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroConfigImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroConfigImpl.java
@@ -91,8 +91,7 @@ public class HieroConfigImpl implements HieroConfig {
     try {
       return PrivateKey.fromString(privateKey);
     } catch (Exception e) {
-      throw new IllegalArgumentException(
-          "Can not parse 'privateKey' property: '" + privateKey + "'", e);
+      throw new IllegalArgumentException("Can not parse 'privateKey' property", e);
     }
   }
 


### PR DESCRIPTION
## Summary

Two related leaks of the operator private key into log/error sinks. Same root cause (a sensitive config value being interpolated into a string sink), two locations.

### 1. `HieroConfigImpl.parsePrivateKey` (Spring) — error path

`HieroConfigImpl.parsePrivateKey` interpolated the raw key into the `IllegalArgumentException` message:

```java
throw new IllegalArgumentException(
    "Can not parse 'privateKey' property: '" + privateKey + "'", e);
```

A malformed value at startup causes Spring to print this message to stdout/stderr as part of the startup failure banner, where it is captured by container runtimes, CI logs and log aggregators. Even a "malformed" key is sensitive — it usually differs from the real key by a typo or extra whitespace.

Fix: drop the value from the message; keep the original exception as the cause so the underlying parser error remains available for debugging.

```diff
-      throw new IllegalArgumentException(
-          "Can not parse 'privateKey' property: '" + privateKey + "'", e);
+      throw new IllegalArgumentException("Can not parse 'privateKey' property", e);
```

### 2. `TestConfigSource` (MicroProfile tests) — happy path

`TestConfigSource` constructed a property map and then logged every entry at INFO:

```java
properties.forEach((k, v) -> log.info("CONFIG: '" + k + "'->'" + v + "'"));
```

The dotenv passthrough immediately above already filters `hiero.privateKey` out of the stream because it is sensitive, but the log statement still printed the value that was inserted directly from `HEDERA_PRIVATE_KEY` / `dotenv.get("hiero.privateKey")` earlier in the constructor. Result: the operator private key was written to the test logs on every test run, including in CI.

Fix: redact the value when the key is `hiero.privateKey`.

```diff
-    properties.forEach((k, v) -> log.info("CONFIG: '" + k + "'->'" + v + "'"));
+    properties.forEach(
+        (k, v) ->
+            log.info("CONFIG: '" + k + "'->'" + ("hiero.privateKey".equals(k) ? "***" : v) + "'"));
```

## Changes

- `hiero-enterprise-spring/.../HieroConfigImpl.java`: remove key value from exception message.
- `hiero-enterprise-microprofile/.../test/TestConfigSource.java`: redact `hiero.privateKey` value in log output.

No behavioural change beyond the message/log contents. Exception types, stack traces, causes and config map contents are preserved.

## Test plan

- [x] `mvn -pl hiero-enterprise-spring -am compile`
- [x] `mvn -pl hiero-enterprise-microprofile -am test-compile`
- [ ] CI green
- [ ] Manual (Spring): start the sample with an invalid `hiero.privateKey` and confirm the startup log shows the message without the key value
- [ ] Manual (MicroProfile): run the test suite with a real `HEDERA_PRIVATE_KEY` set and confirm `CONFIG: 'hiero.privateKey'->'***'` appears in the log
