### PR TITLE
feat: implement annotation-driven event observer framework

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,6 +54,11 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v2.10.1
+      with:
+        egress-policy: audit
+
     - name: Checkout repository
       uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2.10.1
+        with:
+          egress-policy: audit
+
       - name: Checkout Repo
         uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,11 @@ jobs:
       # actions: read
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2.10.1
+        with:
+          egress-policy: audit
+
       - name: "Checkout code"
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ replay_pid*
 **/pom.xml.versionsBackup
 
 site/
+*.code-workspace

--- a/hiero-enterprise-base/src/main/java/module-info.java
+++ b/hiero-enterprise-base/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module org.hiero.base {
   exports org.hiero.base.verification;
   exports org.hiero.base.data;
   exports org.hiero.base.config;
+  exports org.hiero.base.observer;
   exports org.hiero.base.implementation to
       org.hiero.base.test;
   exports org.hiero.base.implementation.data to

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TopicRepositoryImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TopicRepositoryImpl.java
@@ -32,6 +32,14 @@ public class TopicRepositoryImpl implements TopicRepository {
   }
 
   @Override
+  public @NonNull Page<TopicMessage> getMessages(@NonNull TopicId topicId, @NonNull java.time.Instant after)
+      throws HieroException {
+    Objects.requireNonNull(topicId, "topicId must not be null");
+    Objects.requireNonNull(after, "after must not be null");
+    return mirrorNodeClient.queryTopicMessages(topicId, after);
+  }
+
+  @Override
   public @NonNull Optional<TopicMessage> getMessageBySequenceNumber(
       TopicId topicId, long sequenceNumber) throws HieroException {
     Objects.requireNonNull(topicId, "topicId must not be null");

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TopicRepositoryImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TopicRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.hiero.base.implementation;
 
 import com.hedera.hashgraph.sdk.TopicId;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import org.hiero.base.HieroException;
@@ -32,7 +33,7 @@ public class TopicRepositoryImpl implements TopicRepository {
   }
 
   @Override
-  public @NonNull Page<TopicMessage> getMessages(@NonNull TopicId topicId, @NonNull java.time.Instant after)
+  public @NonNull Page<TopicMessage> getMessages(@NonNull TopicId topicId, @NonNull Instant after)
       throws HieroException {
     Objects.requireNonNull(topicId, "topicId must not be null");
     Objects.requireNonNull(after, "after must not be null");

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TransactionRepositoryImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TransactionRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.hiero.base.implementation;
 
 import com.hedera.hashgraph.sdk.AccountId;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import org.hiero.base.HieroException;
@@ -31,7 +32,7 @@ public class TransactionRepositoryImpl implements TransactionRepository {
 
   @Override
   public @NonNull Page<TransactionInfo> findByAccount(
-      @NonNull AccountId accountId, @NonNull java.time.Instant after) throws HieroException {
+      @NonNull AccountId accountId, @NonNull Instant after) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(after, "after must not be null");
     return this.mirrorNodeClient.queryTransactionsByAccount(accountId, after);

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TransactionRepositoryImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TransactionRepositoryImpl.java
@@ -30,6 +30,14 @@ public class TransactionRepositoryImpl implements TransactionRepository {
   }
 
   @Override
+  public @NonNull Page<TransactionInfo> findByAccount(
+      @NonNull AccountId accountId, @NonNull java.time.Instant after) throws HieroException {
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    Objects.requireNonNull(after, "after must not be null");
+    return this.mirrorNodeClient.queryTransactionsByAccount(accountId, after);
+  }
+
+  @Override
   public @NonNull Page<TransactionInfo> findByAccountAndType(
       @NonNull AccountId accountId, @NonNull TransactionType type) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
@@ -4,6 +4,7 @@ import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -183,8 +184,7 @@ public interface MirrorNodeClient {
    * @return a page of transaction information
    * @throws HieroException if an error occurs during the query
    */
-  @NonNull
-  Page<TransactionInfo> queryTransactionsByAccount(@NonNull AccountId accountId, @NonNull java.time.Instant after)
+  @NonNull Page<TransactionInfo> queryTransactionsByAccount(@NonNull AccountId accountId, @NonNull Instant after)
       throws HieroException;
 
   /**
@@ -416,8 +416,7 @@ public interface MirrorNodeClient {
    * @return Page of TopicMessage
    * @throws HieroException if the search fails
    */
-  @NonNull
-  Page<TopicMessage> queryTopicMessages(@NonNull TopicId topicId, @NonNull java.time.Instant after)
+  @NonNull Page<TopicMessage> queryTopicMessages(@NonNull TopicId topicId, @NonNull Instant after)
       throws HieroException;
 
   /**

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
@@ -184,8 +184,8 @@ public interface MirrorNodeClient {
    * @return a page of transaction information
    * @throws HieroException if an error occurs during the query
    */
-  @NonNull Page<TransactionInfo> queryTransactionsByAccount(@NonNull AccountId accountId, @NonNull Instant after)
-      throws HieroException;
+  @NonNull Page<TransactionInfo> queryTransactionsByAccount(
+      @NonNull AccountId accountId, @NonNull Instant after) throws HieroException;
 
   /**
    * Queries all transactions for a specific account and transaction type.

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
@@ -176,6 +176,18 @@ public interface MirrorNodeClient {
       throws HieroException;
 
   /**
+   * Queries transactions for a specific account after a certain timestamp.
+   *
+   * @param accountId the account ID to query transactions for
+   * @param after the timestamp to start querying from (exclusive)
+   * @return a page of transaction information
+   * @throws HieroException if an error occurs during the query
+   */
+  @NonNull
+  Page<TransactionInfo> queryTransactionsByAccount(@NonNull AccountId accountId, @NonNull java.time.Instant after)
+      throws HieroException;
+
+  /**
    * Queries all transactions for a specific account and transaction type.
    *
    * @param accountId the account ID to query transactions for
@@ -395,6 +407,18 @@ public interface MirrorNodeClient {
    * @throws HieroException if the search fails
    */
   @NonNull Page<TopicMessage> queryTopicMessages(TopicId topicId) throws HieroException;
+
+  /**
+   * Return TopicMessages for given topicId after a certain timestamp.
+   *
+   * @param topicId id of the topic
+   * @param after the timestamp to start querying from (exclusive)
+   * @return Page of TopicMessage
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  Page<TopicMessage> queryTopicMessages(@NonNull TopicId topicId, @NonNull java.time.Instant after)
+      throws HieroException;
 
   /**
    * Return TopicMessages for given topicId.

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TopicRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TopicRepository.java
@@ -1,6 +1,7 @@
 package org.hiero.base.mirrornode;
 
 import com.hedera.hashgraph.sdk.TopicId;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import org.hiero.base.HieroException;
@@ -57,7 +58,34 @@ public interface TopicRepository {
     Objects.requireNonNull(topicId, "topicId must not be null");
     return getMessages(TopicId.fromString(topicId));
   }
-  ;
+
+  /**
+   * Return TopicMessages for given topicId after a certain timestamp.
+   *
+   * @param topicId id of the topic
+   * @param after the timestamp to start querying from (exclusive)
+   * @return Page of TopicMessage
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  Page<TopicMessage> getMessages(@NonNull TopicId topicId, @NonNull Instant after)
+      throws HieroException;
+
+  /**
+   * Return TopicMessages for given topicId after a certain timestamp.
+   *
+   * @param topicId id of the topic
+   * @param after the timestamp to start querying from (exclusive)
+   * @return Page of TopicMessage
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  default Page<TopicMessage> getMessages(@NonNull String topicId, @NonNull Instant after)
+      throws HieroException {
+    Objects.requireNonNull(topicId, "topicId must not be null");
+    Objects.requireNonNull(after, "after must not be null");
+    return getMessages(TopicId.fromString(topicId), after);
+  }
 
   /**
    * Return TopicMessage for given topicId.

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TopicRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TopicRepository.java
@@ -67,8 +67,7 @@ public interface TopicRepository {
    * @return Page of TopicMessage
    * @throws HieroException if the search fails
    */
-  @NonNull
-  Page<TopicMessage> getMessages(@NonNull TopicId topicId, @NonNull Instant after)
+  @NonNull Page<TopicMessage> getMessages(@NonNull TopicId topicId, @NonNull Instant after)
       throws HieroException;
 
   /**
@@ -79,8 +78,7 @@ public interface TopicRepository {
    * @return Page of TopicMessage
    * @throws HieroException if the search fails
    */
-  @NonNull
-  default Page<TopicMessage> getMessages(@NonNull String topicId, @NonNull Instant after)
+  @NonNull default Page<TopicMessage> getMessages(@NonNull String topicId, @NonNull Instant after)
       throws HieroException {
     Objects.requireNonNull(topicId, "topicId must not be null");
     Objects.requireNonNull(after, "after must not be null");

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TopicRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TopicRepository.java
@@ -78,7 +78,8 @@ public interface TopicRepository {
    * @return Page of TopicMessage
    * @throws HieroException if the search fails
    */
-  @NonNull default Page<TopicMessage> getMessages(@NonNull String topicId, @NonNull Instant after)
+  @NonNull
+  default Page<TopicMessage> getMessages(@NonNull String topicId, @NonNull Instant after)
       throws HieroException {
     Objects.requireNonNull(topicId, "topicId must not be null");
     Objects.requireNonNull(after, "after must not be null");

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
@@ -47,8 +47,7 @@ public interface TransactionRepository {
    * @return page of transactions
    * @throws HieroException if the search fails
    */
-  @NonNull
-  Page<TransactionInfo> findByAccount(@NonNull AccountId accountId, @NonNull Instant after)
+  @NonNull Page<TransactionInfo> findByAccount(@NonNull AccountId accountId, @NonNull Instant after)
       throws HieroException;
 
   /**
@@ -59,8 +58,7 @@ public interface TransactionRepository {
    * @return page of transactions
    * @throws HieroException if the search fails
    */
-  @NonNull
-  default Page<TransactionInfo> findByAccount(@NonNull String accountId, @NonNull Instant after)
+  @NonNull default Page<TransactionInfo> findByAccount(@NonNull String accountId, @NonNull Instant after)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(after, "after must not be null");

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
@@ -58,7 +58,8 @@ public interface TransactionRepository {
    * @return page of transactions
    * @throws HieroException if the search fails
    */
-  @NonNull default Page<TransactionInfo> findByAccount(@NonNull String accountId, @NonNull Instant after)
+  @NonNull
+  default Page<TransactionInfo> findByAccount(@NonNull String accountId, @NonNull Instant after)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(after, "after must not be null");

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
@@ -1,6 +1,7 @@
 package org.hiero.base.mirrornode;
 
 import com.hedera.hashgraph.sdk.AccountId;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import org.hiero.base.HieroException;
@@ -36,6 +37,34 @@ public interface TransactionRepository {
   default Page<TransactionInfo> findByAccount(@NonNull String accountId) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     return findByAccount(AccountId.fromString(accountId));
+  }
+
+  /**
+   * Find all transactions associated with a specific account after a certain timestamp.
+   *
+   * @param accountId id of the account
+   * @param after the timestamp to start querying from (exclusive)
+   * @return page of transactions
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  Page<TransactionInfo> findByAccount(@NonNull AccountId accountId, @NonNull Instant after)
+      throws HieroException;
+
+  /**
+   * Find all transactions associated with a specific account after a certain timestamp.
+   *
+   * @param accountId id of the account as a string
+   * @param after the timestamp to start querying from (exclusive)
+   * @return page of transactions
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  default Page<TransactionInfo> findByAccount(@NonNull String accountId, @NonNull Instant after)
+      throws HieroException {
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    Objects.requireNonNull(after, "after must not be null");
+    return findByAccount(AccountId.fromString(accountId), after);
   }
 
   /**

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/AbstractPollingObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/AbstractPollingObserver.java
@@ -29,17 +29,17 @@ public abstract class AbstractPollingObserver<T> {
     /**
      * Creates a new polling observer.
      *
+     * @param executorService The shared executor service to use for polling.
      * @param pollingInterval How often to check for new events.
      * @param listener The callback to trigger when an event is found.
      */
-    protected AbstractPollingObserver(@NonNull Duration pollingInterval, @NonNull EventObserver<T> listener) {
+    protected AbstractPollingObserver(
+            @NonNull ScheduledExecutorService executorService,
+            @NonNull Duration pollingInterval,
+            @NonNull EventObserver<T> listener) {
+        this.executorService = executorService;
         this.pollingInterval = pollingInterval;
         this.listener = listener;
-        this.executorService = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread thread = new Thread(r, "hiero-observer-" + getClass().getSimpleName());
-            thread.setDaemon(true);
-            return thread;
-        });
     }
 
     /**
@@ -48,7 +48,13 @@ public abstract class AbstractPollingObserver<T> {
     public void start() {
         if (running.compareAndSet(false, true)) {
             log.info("Starting Hiero observer: {}", getClass().getSimpleName());
-            executorService.scheduleAtFixedRate(this::pollSafe, 0, pollingInterval.toMillis(), TimeUnit.MILLISECONDS);
+            scheduleNext(0);
+        }
+    }
+
+    private void scheduleNext(long delayMs) {
+        if (running.get()) {
+            executorService.schedule(this::pollSafe, delayMs, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -56,26 +62,29 @@ public abstract class AbstractPollingObserver<T> {
      * Stops the background polling task.
      */
     public void stop() {
-        if (running.compareAndSet(true, false)) {
-            log.info("Stopping Hiero observer: {}", getClass().getSimpleName());
-            executorService.shutdown();
-        }
+        running.set(false);
+        log.info("Stopping Hiero observer: {}", getClass().getSimpleName());
     }
 
     private void pollSafe() {
         try {
-            poll();
+            boolean hasMore = poll();
+            // If there's more data (pagination), poll again immediately.
+            // Otherwise, wait for the polling interval.
+            scheduleNext(hasMore ? 0 : pollingInterval.toMillis());
         } catch (Exception e) {
             log.error("Unexpected error during Hiero polling in {}", getClass().getSimpleName(), e);
+            scheduleNext(pollingInterval.toMillis());
         }
     }
 
     /**
      * The actual polling logic to be implemented by subclasses.
      *
+     * @return true if there is more data to poll immediately (pagination), false otherwise.
      * @throws Exception if polling fails.
      */
-    public abstract void poll() throws Exception;
+    public abstract boolean poll() throws Exception;
 
     /**
      * Notifies the listener of a new event.

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/AbstractPollingObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/AbstractPollingObserver.java
@@ -1,0 +1,92 @@
+package org.hiero.base.observer;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base implementation for observers that poll the Mirror Node at regular intervals.
+ *
+ * <p>This class handles the lifecycle of the background polling task, including
+ * starting, stopping, and handling unexpected errors during polling.
+ *
+ * @param <T> The type of event being observed.
+ */
+public abstract class AbstractPollingObserver<T> {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractPollingObserver.class);
+
+    private final ScheduledExecutorService executorService;
+    private final Duration pollingInterval;
+    private final EventObserver<T> listener;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    /**
+     * Creates a new polling observer.
+     *
+     * @param pollingInterval How often to check for new events.
+     * @param listener The callback to trigger when an event is found.
+     */
+    protected AbstractPollingObserver(@NonNull Duration pollingInterval, @NonNull EventObserver<T> listener) {
+        this.pollingInterval = pollingInterval;
+        this.listener = listener;
+        this.executorService = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread thread = new Thread(r, "hiero-observer-" + getClass().getSimpleName());
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    /**
+     * Starts the background polling task.
+     */
+    public void start() {
+        if (running.compareAndSet(false, true)) {
+            log.info("Starting Hiero observer: {}", getClass().getSimpleName());
+            executorService.scheduleAtFixedRate(this::pollSafe, 0, pollingInterval.toMillis(), TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Stops the background polling task.
+     */
+    public void stop() {
+        if (running.compareAndSet(true, false)) {
+            log.info("Stopping Hiero observer: {}", getClass().getSimpleName());
+            executorService.shutdown();
+        }
+    }
+
+    private void pollSafe() {
+        try {
+            poll();
+        } catch (Exception e) {
+            log.error("Unexpected error during Hiero polling in {}", getClass().getSimpleName(), e);
+        }
+    }
+
+    /**
+     * The actual polling logic to be implemented by subclasses.
+     *
+     * @throws Exception if polling fails.
+     */
+    protected abstract void poll() throws Exception;
+
+    /**
+     * Notifies the listener of a new event.
+     *
+     * @param event The event to notify.
+     */
+    protected void notifyListener(@NonNull T event) {
+        try {
+            listener.onEvent(event);
+        } catch (Exception e) {
+            log.error("Error in event listener callback", e);
+        }
+    }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/AbstractPollingObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/AbstractPollingObserver.java
@@ -75,7 +75,7 @@ public abstract class AbstractPollingObserver<T> {
      *
      * @throws Exception if polling fails.
      */
-    protected abstract void poll() throws Exception;
+    public abstract void poll() throws Exception;
 
     /**
      * Notifies the listener of a new event.

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/AbstractPollingObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/AbstractPollingObserver.java
@@ -1,7 +1,6 @@
 package org.hiero.base.observer;
 
 import java.time.Duration;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -12,90 +11,86 @@ import org.slf4j.LoggerFactory;
 /**
  * Base implementation for observers that poll the Mirror Node at regular intervals.
  *
- * <p>This class handles the lifecycle of the background polling task, including
- * starting, stopping, and handling unexpected errors during polling.
+ * <p>This class handles the lifecycle of the background polling task, including starting, stopping,
+ * and handling unexpected errors during polling.
  *
  * @param <T> The type of event being observed.
  */
 public abstract class AbstractPollingObserver<T> {
 
-    private static final Logger log = LoggerFactory.getLogger(AbstractPollingObserver.class);
+  private static final Logger log = LoggerFactory.getLogger(AbstractPollingObserver.class);
 
-    private final ScheduledExecutorService executorService;
-    private final Duration pollingInterval;
-    private final EventObserver<T> listener;
-    private final AtomicBoolean running = new AtomicBoolean(false);
+  private final ScheduledExecutorService executorService;
+  private final Duration pollingInterval;
+  private final EventObserver<T> listener;
+  private final AtomicBoolean running = new AtomicBoolean(false);
 
-    /**
-     * Creates a new polling observer.
-     *
-     * @param executorService The shared executor service to use for polling.
-     * @param pollingInterval How often to check for new events.
-     * @param listener The callback to trigger when an event is found.
-     */
-    protected AbstractPollingObserver(
-            @NonNull ScheduledExecutorService executorService,
-            @NonNull Duration pollingInterval,
-            @NonNull EventObserver<T> listener) {
-        this.executorService = executorService;
-        this.pollingInterval = pollingInterval;
-        this.listener = listener;
+  /**
+   * Creates a new polling observer.
+   *
+   * @param executorService The shared executor service to use for polling.
+   * @param pollingInterval How often to check for new events.
+   * @param listener The callback to trigger when an event is found.
+   */
+  protected AbstractPollingObserver(
+      @NonNull ScheduledExecutorService executorService,
+      @NonNull Duration pollingInterval,
+      @NonNull EventObserver<T> listener) {
+    this.executorService = executorService;
+    this.pollingInterval = pollingInterval;
+    this.listener = listener;
+  }
+
+  /** Starts the background polling task. */
+  public void start() {
+    if (running.compareAndSet(false, true)) {
+      log.info("Starting Hiero observer: {}", getClass().getSimpleName());
+      scheduleNext(0);
     }
+  }
 
-    /**
-     * Starts the background polling task.
-     */
-    public void start() {
-        if (running.compareAndSet(false, true)) {
-            log.info("Starting Hiero observer: {}", getClass().getSimpleName());
-            scheduleNext(0);
-        }
+  private void scheduleNext(long delayMs) {
+    if (running.get()) {
+      executorService.schedule(this::pollSafe, delayMs, TimeUnit.MILLISECONDS);
     }
+  }
 
-    private void scheduleNext(long delayMs) {
-        if (running.get()) {
-            executorService.schedule(this::pollSafe, delayMs, TimeUnit.MILLISECONDS);
-        }
+  /** Stops the background polling task. */
+  public void stop() {
+    running.set(false);
+    log.info("Stopping Hiero observer: {}", getClass().getSimpleName());
+  }
+
+  private void pollSafe() {
+    try {
+      boolean hasMore = poll();
+      // If there's more data (pagination), poll again immediately.
+      // Otherwise, wait for the polling interval.
+      scheduleNext(hasMore ? 0 : pollingInterval.toMillis());
+    } catch (Exception e) {
+      log.error("Unexpected error during Hiero polling in {}", getClass().getSimpleName(), e);
+      scheduleNext(pollingInterval.toMillis());
     }
+  }
 
-    /**
-     * Stops the background polling task.
-     */
-    public void stop() {
-        running.set(false);
-        log.info("Stopping Hiero observer: {}", getClass().getSimpleName());
+  /**
+   * The actual polling logic to be implemented by subclasses.
+   *
+   * @return true if there is more data to poll immediately (pagination), false otherwise.
+   * @throws Exception if polling fails.
+   */
+  public abstract boolean poll() throws Exception;
+
+  /**
+   * Notifies the listener of a new event.
+   *
+   * @param event The event to notify.
+   */
+  protected void notifyListener(@NonNull T event) {
+    try {
+      listener.onEvent(event);
+    } catch (Exception e) {
+      log.error("Error in event listener callback", e);
     }
-
-    private void pollSafe() {
-        try {
-            boolean hasMore = poll();
-            // If there's more data (pagination), poll again immediately.
-            // Otherwise, wait for the polling interval.
-            scheduleNext(hasMore ? 0 : pollingInterval.toMillis());
-        } catch (Exception e) {
-            log.error("Unexpected error during Hiero polling in {}", getClass().getSimpleName(), e);
-            scheduleNext(pollingInterval.toMillis());
-        }
-    }
-
-    /**
-     * The actual polling logic to be implemented by subclasses.
-     *
-     * @return true if there is more data to poll immediately (pagination), false otherwise.
-     * @throws Exception if polling fails.
-     */
-    public abstract boolean poll() throws Exception;
-
-    /**
-     * Notifies the listener of a new event.
-     *
-     * @param event The event to notify.
-     */
-    protected void notifyListener(@NonNull T event) {
-        try {
-            listener.onEvent(event);
-        } catch (Exception e) {
-            log.error("Error in event listener callback", e);
-        }
-    }
+  }
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/EventObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/EventObserver.java
@@ -1,0 +1,20 @@
+package org.hiero.base.observer;
+
+/**
+ * Functional interface for a component that observes events on the Hiero network.
+ *
+ * <p>Implementations of this interface typically run in a background thread or are
+ * triggered by a scheduler to check for new network activities.
+ *
+ * @param <T> The type of event being observed (e.g., TransactionInfo, TopicMessage).
+ */
+@FunctionalInterface
+public interface EventObserver<T> {
+
+    /**
+     * Called when a new event is detected.
+     *
+     * @param event The detected event.
+     */
+    void onEvent(T event);
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/EventObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/EventObserver.java
@@ -3,18 +3,18 @@ package org.hiero.base.observer;
 /**
  * Functional interface for a component that observes events on the Hiero network.
  *
- * <p>Implementations of this interface typically run in a background thread or are
- * triggered by a scheduler to check for new network activities.
+ * <p>Implementations of this interface typically run in a background thread or are triggered by a
+ * scheduler to check for new network activities.
  *
  * @param <T> The type of event being observed (e.g., TransactionInfo, TopicMessage).
  */
 @FunctionalInterface
 public interface EventObserver<T> {
 
-    /**
-     * Called when a new event is detected.
-     *
-     * @param event The detected event.
-     */
-    void onEvent(T event);
+  /**
+   * Called when a new event is detected.
+   *
+   * @param event The detected event.
+   */
+  void onEvent(T event);
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TopicObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TopicObserver.java
@@ -1,0 +1,77 @@
+package org.hiero.base.observer;
+
+import com.hedera.hashgraph.sdk.TopicId;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import org.hiero.base.data.Page;
+import org.hiero.base.data.TopicMessage;
+import org.hiero.base.mirrornode.TopicRepository;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Observer that polls for new messages on a specific Hiero Consensus Service (HCS) topic.
+ */
+public class TopicObserver extends AbstractPollingObserver<TopicMessage> {
+
+    private static final Logger log = LoggerFactory.getLogger(TopicObserver.class);
+
+    private final TopicRepository repository;
+    private final TopicId topicId;
+    private Instant lastSeenTimestamp;
+
+    /**
+     * Creates a new topic observer.
+     *
+     * @param repository The repository to use for polling.
+     * @param topicId The topic to monitor.
+     * @param pollingInterval How often to poll the mirror node.
+     * @param listener The callback for new messages.
+     */
+    public TopicObserver(
+            @NonNull TopicRepository repository,
+            @NonNull TopicId topicId,
+            @NonNull Duration pollingInterval,
+            @NonNull EventObserver<TopicMessage> listener) {
+        super(pollingInterval, listener);
+        this.repository = repository;
+        this.topicId = topicId;
+        this.lastSeenTimestamp = Instant.now();
+    }
+
+    @Override
+    protected void poll() throws Exception {
+        log.trace("Polling messages for topic {} after {}", topicId, lastSeenTimestamp);
+
+        Page<TopicMessage> page = repository.getMessages(topicId, lastSeenTimestamp);
+        List<TopicMessage> messages = page.getData();
+
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        // Sort by timestamp to ensure chronological delivery
+        messages.sort(Comparator.comparing(TopicMessage::consensusTimestamp));
+
+        for (TopicMessage msg : messages) {
+            notifyListener(msg);
+            if (msg.consensusTimestamp().isAfter(lastSeenTimestamp)) {
+                lastSeenTimestamp = msg.consensusTimestamp();
+            }
+        }
+    }
+
+    /**
+     * Sets the starting timestamp for the observer.
+     *
+     * @param timestamp The timestamp to start from.
+     * @return this observer for chaining.
+     */
+    public TopicObserver startFrom(@NonNull Instant timestamp) {
+        this.lastSeenTimestamp = timestamp;
+        return this;
+    }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TopicObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TopicObserver.java
@@ -13,73 +13,71 @@ import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Observer that polls for new messages on a specific Hiero Consensus Service (HCS) topic.
- */
+/** Observer that polls for new messages on a specific Hiero Consensus Service (HCS) topic. */
 public class TopicObserver extends AbstractPollingObserver<TopicMessage> {
 
-    private static final Logger log = LoggerFactory.getLogger(TopicObserver.class);
+  private static final Logger log = LoggerFactory.getLogger(TopicObserver.class);
 
-    private final TopicRepository repository;
-    private final TopicId topicId;
-    private Instant lastSeenTimestamp;
+  private final TopicRepository repository;
+  private final TopicId topicId;
+  private Instant lastSeenTimestamp;
 
-    /**
-     * Creates a new topic observer.
-     *
-     * @param executorService The shared executor service to use for polling.
-     * @param repository The repository to use for polling.
-     * @param topicId The topic to monitor.
-     * @param pollingInterval How often to poll the mirror node.
-     * @param listener The callback for new messages.
-     */
-    public TopicObserver(
-            @NonNull ScheduledExecutorService executorService,
-            @NonNull TopicRepository repository,
-            @NonNull TopicId topicId,
-            @NonNull Duration pollingInterval,
-            @NonNull EventObserver<TopicMessage> listener) {
-        super(executorService, pollingInterval, listener);
-        this.repository = repository;
-        this.topicId = topicId;
-        this.lastSeenTimestamp = Instant.now();
+  /**
+   * Creates a new topic observer.
+   *
+   * @param executorService The shared executor service to use for polling.
+   * @param repository The repository to use for polling.
+   * @param topicId The topic to monitor.
+   * @param pollingInterval How often to poll the mirror node.
+   * @param listener The callback for new messages.
+   */
+  public TopicObserver(
+      @NonNull ScheduledExecutorService executorService,
+      @NonNull TopicRepository repository,
+      @NonNull TopicId topicId,
+      @NonNull Duration pollingInterval,
+      @NonNull EventObserver<TopicMessage> listener) {
+    super(executorService, pollingInterval, listener);
+    this.repository = repository;
+    this.topicId = topicId;
+    this.lastSeenTimestamp = Instant.now();
+  }
+
+  @Override
+  public boolean poll() throws Exception {
+    log.trace("Polling messages for topic {} after {}", topicId, lastSeenTimestamp);
+
+    Page<TopicMessage> page = repository.getMessages(topicId, lastSeenTimestamp);
+    processPage(page);
+
+    return page.hasNext();
+  }
+
+  private void processPage(Page<TopicMessage> page) {
+    List<TopicMessage> messages = new java.util.ArrayList<>(page.getData());
+    if (messages.isEmpty()) {
+      return;
     }
 
-    @Override
-    public boolean poll() throws Exception {
-        log.trace("Polling messages for topic {} after {}", topicId, lastSeenTimestamp);
+    // Sort by timestamp to ensure chronological delivery
+    messages.sort(Comparator.comparing(TopicMessage::consensusTimestamp));
 
-        Page<TopicMessage> page = repository.getMessages(topicId, lastSeenTimestamp);
-        processPage(page);
-
-        return page.hasNext();
+    for (TopicMessage msg : messages) {
+      if (msg.consensusTimestamp().isAfter(lastSeenTimestamp)) {
+        notifyListener(msg);
+        lastSeenTimestamp = msg.consensusTimestamp();
+      }
     }
+  }
 
-    private void processPage(Page<TopicMessage> page) {
-        List<TopicMessage> messages = new java.util.ArrayList<>(page.getData());
-        if (messages.isEmpty()) {
-            return;
-        }
-
-        // Sort by timestamp to ensure chronological delivery
-        messages.sort(Comparator.comparing(TopicMessage::consensusTimestamp));
-
-        for (TopicMessage msg : messages) {
-            if (msg.consensusTimestamp().isAfter(lastSeenTimestamp)) {
-                notifyListener(msg);
-                lastSeenTimestamp = msg.consensusTimestamp();
-            }
-        }
-    }
-
-    /**
-     * Sets the starting timestamp for the observer.
-     *
-     * @param timestamp The timestamp to start from.
-     * @return this observer for chaining.
-     */
-    public TopicObserver startFrom(@NonNull Instant timestamp) {
-        this.lastSeenTimestamp = timestamp;
-        return this;
-    }
+  /**
+   * Sets the starting timestamp for the observer.
+   *
+   * @param timestamp The timestamp to start from.
+   * @return this observer for chaining.
+   */
+  public TopicObserver startFrom(@NonNull Instant timestamp) {
+    this.lastSeenTimestamp = timestamp;
+    return this;
+  }
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TopicObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TopicObserver.java
@@ -43,11 +43,11 @@ public class TopicObserver extends AbstractPollingObserver<TopicMessage> {
     }
 
     @Override
-    protected void poll() throws Exception {
+    public void poll() throws Exception {
         log.trace("Polling messages for topic {} after {}", topicId, lastSeenTimestamp);
 
         Page<TopicMessage> page = repository.getMessages(topicId, lastSeenTimestamp);
-        List<TopicMessage> messages = page.getData();
+        List<TopicMessage> messages = new java.util.ArrayList<>(page.getData());
 
         if (messages.isEmpty()) {
             return;
@@ -57,8 +57,8 @@ public class TopicObserver extends AbstractPollingObserver<TopicMessage> {
         messages.sort(Comparator.comparing(TopicMessage::consensusTimestamp));
 
         for (TopicMessage msg : messages) {
-            notifyListener(msg);
             if (msg.consensusTimestamp().isAfter(lastSeenTimestamp)) {
+                notifyListener(msg);
                 lastSeenTimestamp = msg.consensusTimestamp();
             }
         }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TopicObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TopicObserver.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.TopicMessage;
 import org.hiero.base.mirrornode.TopicRepository;
@@ -26,29 +27,36 @@ public class TopicObserver extends AbstractPollingObserver<TopicMessage> {
     /**
      * Creates a new topic observer.
      *
+     * @param executorService The shared executor service to use for polling.
      * @param repository The repository to use for polling.
      * @param topicId The topic to monitor.
      * @param pollingInterval How often to poll the mirror node.
      * @param listener The callback for new messages.
      */
     public TopicObserver(
+            @NonNull ScheduledExecutorService executorService,
             @NonNull TopicRepository repository,
             @NonNull TopicId topicId,
             @NonNull Duration pollingInterval,
             @NonNull EventObserver<TopicMessage> listener) {
-        super(pollingInterval, listener);
+        super(executorService, pollingInterval, listener);
         this.repository = repository;
         this.topicId = topicId;
         this.lastSeenTimestamp = Instant.now();
     }
 
     @Override
-    public void poll() throws Exception {
+    public boolean poll() throws Exception {
         log.trace("Polling messages for topic {} after {}", topicId, lastSeenTimestamp);
 
         Page<TopicMessage> page = repository.getMessages(topicId, lastSeenTimestamp);
-        List<TopicMessage> messages = new java.util.ArrayList<>(page.getData());
+        processPage(page);
 
+        return page.hasNext();
+    }
+
+    private void processPage(Page<TopicMessage> page) {
+        List<TopicMessage> messages = new java.util.ArrayList<>(page.getData());
         if (messages.isEmpty()) {
             return;
         }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TransactionObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TransactionObserver.java
@@ -47,11 +47,11 @@ public class TransactionObserver extends AbstractPollingObserver<TransactionInfo
     }
 
     @Override
-    protected void poll() throws Exception {
+    public void poll() throws Exception {
         log.trace("Polling transactions for account {} after {}", accountId, lastSeenTimestamp);
 
         Page<TransactionInfo> page = repository.findByAccount(accountId, lastSeenTimestamp);
-        List<TransactionInfo> transactions = page.getData();
+        List<TransactionInfo> transactions = new java.util.ArrayList<>(page.getData());
 
         if (transactions.isEmpty()) {
             return;
@@ -61,8 +61,8 @@ public class TransactionObserver extends AbstractPollingObserver<TransactionInfo
         transactions.sort(Comparator.comparing(TransactionInfo::consensusTimestamp));
 
         for (TransactionInfo tx : transactions) {
-            notifyListener(tx);
             if (tx.consensusTimestamp().isAfter(lastSeenTimestamp)) {
+                notifyListener(tx);
                 lastSeenTimestamp = tx.consensusTimestamp();
             }
         }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TransactionObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TransactionObserver.java
@@ -1,0 +1,81 @@
+package org.hiero.base.observer;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import org.hiero.base.data.Page;
+import org.hiero.base.data.TransactionInfo;
+import org.hiero.base.mirrornode.TransactionRepository;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Observer that polls for new transactions associated with a specific account.
+ *
+ * <p>This observer tracks the consensus timestamp of the last processed transaction
+ * to ensure that only new transactions are delivered to the listener.
+ */
+public class TransactionObserver extends AbstractPollingObserver<TransactionInfo> {
+
+    private static final Logger log = LoggerFactory.getLogger(TransactionObserver.class);
+
+    private final TransactionRepository repository;
+    private final AccountId accountId;
+    private Instant lastSeenTimestamp;
+
+    /**
+     * Creates a new transaction observer.
+     *
+     * @param repository The repository to use for polling.
+     * @param accountId The account to monitor.
+     * @param pollingInterval How often to poll the mirror node.
+     * @param listener The callback for new transactions.
+     */
+    public TransactionObserver(
+            @NonNull TransactionRepository repository,
+            @NonNull AccountId accountId,
+            @NonNull Duration pollingInterval,
+            @NonNull EventObserver<TransactionInfo> listener) {
+        super(pollingInterval, listener);
+        this.repository = repository;
+        this.accountId = accountId;
+        // Start from current time to avoid processing historical transactions by default
+        this.lastSeenTimestamp = Instant.now();
+    }
+
+    @Override
+    protected void poll() throws Exception {
+        log.trace("Polling transactions for account {} after {}", accountId, lastSeenTimestamp);
+
+        Page<TransactionInfo> page = repository.findByAccount(accountId, lastSeenTimestamp);
+        List<TransactionInfo> transactions = page.getData();
+
+        if (transactions.isEmpty()) {
+            return;
+        }
+
+        // Sort by timestamp to ensure chronological delivery
+        transactions.sort(Comparator.comparing(TransactionInfo::consensusTimestamp));
+
+        for (TransactionInfo tx : transactions) {
+            notifyListener(tx);
+            if (tx.consensusTimestamp().isAfter(lastSeenTimestamp)) {
+                lastSeenTimestamp = tx.consensusTimestamp();
+            }
+        }
+    }
+
+    /**
+     * Sets the starting timestamp for the observer.
+     *
+     * @param timestamp The timestamp to start from.
+     * @return this observer for chaining.
+     */
+    public TransactionObserver startFrom(@NonNull Instant timestamp) {
+        this.lastSeenTimestamp = timestamp;
+        return this;
+    }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TransactionObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TransactionObserver.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.TransactionInfo;
 import org.hiero.base.mirrornode.TransactionRepository;
@@ -29,17 +30,19 @@ public class TransactionObserver extends AbstractPollingObserver<TransactionInfo
     /**
      * Creates a new transaction observer.
      *
+     * @param executorService The shared executor service to use for polling.
      * @param repository The repository to use for polling.
      * @param accountId The account to monitor.
      * @param pollingInterval How often to poll the mirror node.
      * @param listener The callback for new transactions.
      */
     public TransactionObserver(
+            @NonNull ScheduledExecutorService executorService,
             @NonNull TransactionRepository repository,
             @NonNull AccountId accountId,
             @NonNull Duration pollingInterval,
             @NonNull EventObserver<TransactionInfo> listener) {
-        super(pollingInterval, listener);
+        super(executorService, pollingInterval, listener);
         this.repository = repository;
         this.accountId = accountId;
         // Start from current time to avoid processing historical transactions by default
@@ -47,12 +50,17 @@ public class TransactionObserver extends AbstractPollingObserver<TransactionInfo
     }
 
     @Override
-    public void poll() throws Exception {
+    public boolean poll() throws Exception {
         log.trace("Polling transactions for account {} after {}", accountId, lastSeenTimestamp);
 
         Page<TransactionInfo> page = repository.findByAccount(accountId, lastSeenTimestamp);
-        List<TransactionInfo> transactions = new java.util.ArrayList<>(page.getData());
+        processPage(page);
 
+        return page.hasNext();
+    }
+
+    private void processPage(Page<TransactionInfo> page) {
+        List<TransactionInfo> transactions = new java.util.ArrayList<>(page.getData());
         if (transactions.isEmpty()) {
             return;
         }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TransactionObserver.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/observer/TransactionObserver.java
@@ -16,74 +16,74 @@ import org.slf4j.LoggerFactory;
 /**
  * Observer that polls for new transactions associated with a specific account.
  *
- * <p>This observer tracks the consensus timestamp of the last processed transaction
- * to ensure that only new transactions are delivered to the listener.
+ * <p>This observer tracks the consensus timestamp of the last processed transaction to ensure that
+ * only new transactions are delivered to the listener.
  */
 public class TransactionObserver extends AbstractPollingObserver<TransactionInfo> {
 
-    private static final Logger log = LoggerFactory.getLogger(TransactionObserver.class);
+  private static final Logger log = LoggerFactory.getLogger(TransactionObserver.class);
 
-    private final TransactionRepository repository;
-    private final AccountId accountId;
-    private Instant lastSeenTimestamp;
+  private final TransactionRepository repository;
+  private final AccountId accountId;
+  private Instant lastSeenTimestamp;
 
-    /**
-     * Creates a new transaction observer.
-     *
-     * @param executorService The shared executor service to use for polling.
-     * @param repository The repository to use for polling.
-     * @param accountId The account to monitor.
-     * @param pollingInterval How often to poll the mirror node.
-     * @param listener The callback for new transactions.
-     */
-    public TransactionObserver(
-            @NonNull ScheduledExecutorService executorService,
-            @NonNull TransactionRepository repository,
-            @NonNull AccountId accountId,
-            @NonNull Duration pollingInterval,
-            @NonNull EventObserver<TransactionInfo> listener) {
-        super(executorService, pollingInterval, listener);
-        this.repository = repository;
-        this.accountId = accountId;
-        // Start from current time to avoid processing historical transactions by default
-        this.lastSeenTimestamp = Instant.now();
+  /**
+   * Creates a new transaction observer.
+   *
+   * @param executorService The shared executor service to use for polling.
+   * @param repository The repository to use for polling.
+   * @param accountId The account to monitor.
+   * @param pollingInterval How often to poll the mirror node.
+   * @param listener The callback for new transactions.
+   */
+  public TransactionObserver(
+      @NonNull ScheduledExecutorService executorService,
+      @NonNull TransactionRepository repository,
+      @NonNull AccountId accountId,
+      @NonNull Duration pollingInterval,
+      @NonNull EventObserver<TransactionInfo> listener) {
+    super(executorService, pollingInterval, listener);
+    this.repository = repository;
+    this.accountId = accountId;
+    // Start from current time to avoid processing historical transactions by default
+    this.lastSeenTimestamp = Instant.now();
+  }
+
+  @Override
+  public boolean poll() throws Exception {
+    log.trace("Polling transactions for account {} after {}", accountId, lastSeenTimestamp);
+
+    Page<TransactionInfo> page = repository.findByAccount(accountId, lastSeenTimestamp);
+    processPage(page);
+
+    return page.hasNext();
+  }
+
+  private void processPage(Page<TransactionInfo> page) {
+    List<TransactionInfo> transactions = new java.util.ArrayList<>(page.getData());
+    if (transactions.isEmpty()) {
+      return;
     }
 
-    @Override
-    public boolean poll() throws Exception {
-        log.trace("Polling transactions for account {} after {}", accountId, lastSeenTimestamp);
+    // Sort by timestamp to ensure chronological delivery
+    transactions.sort(Comparator.comparing(TransactionInfo::consensusTimestamp));
 
-        Page<TransactionInfo> page = repository.findByAccount(accountId, lastSeenTimestamp);
-        processPage(page);
-
-        return page.hasNext();
+    for (TransactionInfo tx : transactions) {
+      if (tx.consensusTimestamp().isAfter(lastSeenTimestamp)) {
+        notifyListener(tx);
+        lastSeenTimestamp = tx.consensusTimestamp();
+      }
     }
+  }
 
-    private void processPage(Page<TransactionInfo> page) {
-        List<TransactionInfo> transactions = new java.util.ArrayList<>(page.getData());
-        if (transactions.isEmpty()) {
-            return;
-        }
-
-        // Sort by timestamp to ensure chronological delivery
-        transactions.sort(Comparator.comparing(TransactionInfo::consensusTimestamp));
-
-        for (TransactionInfo tx : transactions) {
-            if (tx.consensusTimestamp().isAfter(lastSeenTimestamp)) {
-                notifyListener(tx);
-                lastSeenTimestamp = tx.consensusTimestamp();
-            }
-        }
-    }
-
-    /**
-     * Sets the starting timestamp for the observer.
-     *
-     * @param timestamp The timestamp to start from.
-     * @return this observer for chaining.
-     */
-    public TransactionObserver startFrom(@NonNull Instant timestamp) {
-        this.lastSeenTimestamp = timestamp;
-        return this;
-    }
+  /**
+   * Sets the starting timestamp for the observer.
+   *
+   * @param timestamp The timestamp to start from.
+   * @return this observer for chaining.
+   */
+  public TransactionObserver startFrom(@NonNull Instant timestamp) {
+    this.lastSeenTimestamp = timestamp;
+    return this;
+  }
 }

--- a/hiero-enterprise-base/src/test/java/org/hiero/base/observer/TransactionObserverTest.java
+++ b/hiero-enterprise-base/src/test/java/org/hiero/base/observer/TransactionObserverTest.java
@@ -1,0 +1,92 @@
+package org.hiero.base.observer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import org.hiero.base.data.Page;
+import org.hiero.base.data.TransactionInfo;
+import org.hiero.base.mirrornode.TransactionRepository;
+import org.hiero.base.protocol.data.TransactionType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class TransactionObserverTest {
+
+    @Mock
+    private TransactionRepository repository;
+
+    @Mock
+    private EventObserver<TransactionInfo> listener;
+
+    private TransactionObserver observer;
+    private final AccountId accountId = AccountId.fromString("0.0.1234");
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        observer = new TransactionObserver(repository, accountId, Duration.ofMillis(100), listener);
+    }
+
+    @Test
+    void testPollDetectsNewTransactions() throws Exception {
+        // Setup timestamps
+        Instant now = Instant.now();
+        Instant txTime = now.plusSeconds(1);
+        
+        TransactionInfo tx = new TransactionInfo(
+                "0.0.1234@1234567890.000000001",
+                null, 0, txTime, null, "100", null,
+                TransactionType.CRYPTOTRANSFER, Collections.emptyList(), null, 0, null,
+                "SUCCESS", false, Collections.emptyList(), Collections.emptyList(), null,
+                Collections.emptyList(), "120", Instant.now()
+        );
+
+        when(repository.findByAccount(eq(accountId), any(Instant.class)))
+                .thenReturn(new Page<>() {
+                    @Override public int getPageIndex() { return 0; }
+                    @Override public int getSize() { return 1; }
+                    @Override public List<TransactionInfo> getData() { return List.of(tx); }
+                    @Override public boolean hasNext() { return false; }
+                    @Override public Page<TransactionInfo> next() { return null; }
+                    @Override public Page<TransactionInfo> first() { return this; }
+                    @Override public boolean isFirst() { return true; }
+                });
+
+        // First poll should use start timestamp (now)
+        observer.poll();
+
+        verify(listener, times(1)).onEvent(tx);
+    }
+
+    @Test
+    void testPollIgnoresDuplicates() throws Exception {
+        Instant now = Instant.now();
+        TransactionInfo tx = mock(TransactionInfo.class);
+        when(tx.consensusTimestamp()).thenReturn(now.plusSeconds(1));
+
+        when(repository.findByAccount(eq(accountId), any(Instant.class)))
+                .thenReturn(new Page<>() {
+                    @Override public int getPageIndex() { return 0; }
+                    @Override public int getSize() { return 1; }
+                    @Override public List<TransactionInfo> getData() { return List.of(tx); }
+                    @Override public boolean hasNext() { return false; }
+                    @Override public Page<TransactionInfo> next() { return null; }
+                    @Override public Page<TransactionInfo> first() { return this; }
+                    @Override public boolean isFirst() { return true; }
+                });
+
+        observer.poll();
+        observer.poll();
+
+        // Should only notify once if the repository filter works correctly
+        verify(listener, times(1)).onEvent(tx);
+    }
+}

--- a/hiero-enterprise-base/src/test/java/org/hiero/base/test/TransactionObserverTest.java
+++ b/hiero-enterprise-base/src/test/java/org/hiero/base/test/TransactionObserverTest.java
@@ -9,6 +9,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.TransactionInfo;
 import org.hiero.base.mirrornode.TransactionRepository;
@@ -30,11 +32,12 @@ class TransactionObserverTest {
 
     private TransactionObserver observer;
     private final AccountId accountId = AccountId.fromString("0.0.1234");
+    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        observer = new TransactionObserver(repository, accountId, Duration.ofMillis(100), listener);
+        observer = new TransactionObserver(executorService, repository, accountId, Duration.ofMillis(100), listener);
     }
 
     @Test

--- a/hiero-enterprise-base/src/test/java/org/hiero/base/test/TransactionObserverTest.java
+++ b/hiero-enterprise-base/src/test/java/org/hiero/base/test/TransactionObserverTest.java
@@ -1,4 +1,4 @@
-package org.hiero.base.observer;
+package org.hiero.base.test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -12,6 +12,8 @@ import java.util.List;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.TransactionInfo;
 import org.hiero.base.mirrornode.TransactionRepository;
+import org.hiero.base.observer.EventObserver;
+import org.hiero.base.observer.TransactionObserver;
 import org.hiero.base.protocol.data.TransactionType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +46,7 @@ class TransactionObserverTest {
         TransactionInfo tx = new TransactionInfo(
                 "0.0.1234@1234567890.000000001",
                 null, 0, txTime, null, "100", null,
-                TransactionType.CRYPTOTRANSFER, Collections.emptyList(), null, 0, null,
+                TransactionType.CRYPTO_TRANSFER, Collections.emptyList(), null, 0, null,
                 "SUCCESS", false, Collections.emptyList(), Collections.emptyList(), null,
                 Collections.emptyList(), "120", Instant.now()
         );

--- a/hiero-enterprise-base/src/test/java/org/hiero/base/test/TransactionObserverTest.java
+++ b/hiero-enterprise-base/src/test/java/org/hiero/base/test/TransactionObserverTest.java
@@ -24,74 +24,146 @@ import org.mockito.MockitoAnnotations;
 
 class TransactionObserverTest {
 
-    @Mock
-    private TransactionRepository repository;
+  @Mock private TransactionRepository repository;
 
-    @Mock
-    private EventObserver<TransactionInfo> listener;
+  @Mock private EventObserver<TransactionInfo> listener;
 
-    private TransactionObserver observer;
-    private final AccountId accountId = AccountId.fromString("0.0.1234");
-    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+  private TransactionObserver observer;
+  private final AccountId accountId = AccountId.fromString("0.0.1234");
+  private final ScheduledExecutorService executorService =
+      Executors.newSingleThreadScheduledExecutor();
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        observer = new TransactionObserver(executorService, repository, accountId, Duration.ofMillis(100), listener);
-    }
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    observer =
+        new TransactionObserver(
+            executorService, repository, accountId, Duration.ofMillis(100), listener);
+  }
 
-    @Test
-    void testPollDetectsNewTransactions() throws Exception {
-        // Setup timestamps
-        Instant now = Instant.now();
-        Instant txTime = now.plusSeconds(1);
-        
-        TransactionInfo tx = new TransactionInfo(
-                "0.0.1234@1234567890.000000001",
-                null, 0, txTime, null, "100", null,
-                TransactionType.CRYPTO_TRANSFER, Collections.emptyList(), null, 0, null,
-                "SUCCESS", false, Collections.emptyList(), Collections.emptyList(), null,
-                Collections.emptyList(), "120", Instant.now()
-        );
+  @Test
+  void testPollDetectsNewTransactions() throws Exception {
+    // Setup timestamps
+    Instant now = Instant.now();
+    Instant txTime = now.plusSeconds(1);
 
-        when(repository.findByAccount(eq(accountId), any(Instant.class)))
-                .thenReturn(new Page<>() {
-                    @Override public int getPageIndex() { return 0; }
-                    @Override public int getSize() { return 1; }
-                    @Override public List<TransactionInfo> getData() { return List.of(tx); }
-                    @Override public boolean hasNext() { return false; }
-                    @Override public Page<TransactionInfo> next() { return null; }
-                    @Override public Page<TransactionInfo> first() { return this; }
-                    @Override public boolean isFirst() { return true; }
-                });
+    TransactionInfo tx =
+        new TransactionInfo(
+            "0.0.1234@1234567890.000000001",
+            null,
+            0,
+            txTime,
+            null,
+            "100",
+            null,
+            TransactionType.CRYPTO_TRANSFER,
+            Collections.emptyList(),
+            null,
+            0,
+            null,
+            "SUCCESS",
+            false,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            Collections.emptyList(),
+            "120",
+            Instant.now());
 
-        // First poll should use start timestamp (now)
-        observer.poll();
+    when(repository.findByAccount(eq(accountId), any(Instant.class)))
+        .thenReturn(
+            new Page<>() {
+              @Override
+              public int getPageIndex() {
+                return 0;
+              }
 
-        verify(listener, times(1)).onEvent(tx);
-    }
+              @Override
+              public int getSize() {
+                return 1;
+              }
 
-    @Test
-    void testPollIgnoresDuplicates() throws Exception {
-        Instant now = Instant.now();
-        TransactionInfo tx = mock(TransactionInfo.class);
-        when(tx.consensusTimestamp()).thenReturn(now.plusSeconds(1));
+              @Override
+              public List<TransactionInfo> getData() {
+                return List.of(tx);
+              }
 
-        when(repository.findByAccount(eq(accountId), any(Instant.class)))
-                .thenReturn(new Page<>() {
-                    @Override public int getPageIndex() { return 0; }
-                    @Override public int getSize() { return 1; }
-                    @Override public List<TransactionInfo> getData() { return List.of(tx); }
-                    @Override public boolean hasNext() { return false; }
-                    @Override public Page<TransactionInfo> next() { return null; }
-                    @Override public Page<TransactionInfo> first() { return this; }
-                    @Override public boolean isFirst() { return true; }
-                });
+              @Override
+              public boolean hasNext() {
+                return false;
+              }
 
-        observer.poll();
-        observer.poll();
+              @Override
+              public Page<TransactionInfo> next() {
+                return null;
+              }
 
-        // Should only notify once if the repository filter works correctly
-        verify(listener, times(1)).onEvent(tx);
-    }
+              @Override
+              public Page<TransactionInfo> first() {
+                return this;
+              }
+
+              @Override
+              public boolean isFirst() {
+                return true;
+              }
+            });
+
+    // First poll should use start timestamp (now)
+    observer.poll();
+
+    verify(listener, times(1)).onEvent(tx);
+  }
+
+  @Test
+  void testPollIgnoresDuplicates() throws Exception {
+    Instant now = Instant.now();
+    TransactionInfo tx = mock(TransactionInfo.class);
+    when(tx.consensusTimestamp()).thenReturn(now.plusSeconds(1));
+
+    when(repository.findByAccount(eq(accountId), any(Instant.class)))
+        .thenReturn(
+            new Page<>() {
+              @Override
+              public int getPageIndex() {
+                return 0;
+              }
+
+              @Override
+              public int getSize() {
+                return 1;
+              }
+
+              @Override
+              public List<TransactionInfo> getData() {
+                return List.of(tx);
+              }
+
+              @Override
+              public boolean hasNext() {
+                return false;
+              }
+
+              @Override
+              public Page<TransactionInfo> next() {
+                return null;
+              }
+
+              @Override
+              public Page<TransactionInfo> first() {
+                return this;
+              }
+
+              @Override
+              public boolean isFirst() {
+                return true;
+              }
+            });
+
+    observer.poll();
+    observer.poll();
+
+    // Should only notify once if the repository filter works correctly
+    verify(listener, times(1)).onEvent(tx);
+  }
 }

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -65,7 +65,18 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
   public @NonNull Page<TransactionInfo> queryTransactionsByAccount(@NonNull AccountId accountId)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    final String path = "/api/v1/tokens?account.id=" + accountId;
+    final String path = "/api/v1/transactions?account.id=" + accountId;
+    final Function<JsonObject, List<TransactionInfo>> dataExtractionFunction =
+        node -> jsonConverter.toTransactionInfos(node);
+    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+  }
+
+  @Override
+  public @NonNull Page<TransactionInfo> queryTransactionsByAccount(
+      @NonNull AccountId accountId, @NonNull java.time.Instant after) throws HieroException {
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    Objects.requireNonNull(after, "after must not be null");
+    final String path = "/api/v1/transactions?account.id=" + accountId + "&timestamp=gt:" + formatInstant(after);
     final Function<JsonObject, List<TransactionInfo>> dataExtractionFunction =
         node -> jsonConverter.toTransactionInfos(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
@@ -140,6 +151,21 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final Function<JsonObject, List<TopicMessage>> dataExtractionFunction =
         node -> jsonConverter.toTopicMessages(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+  }
+
+  @Override
+  public @NonNull Page<TopicMessage> queryTopicMessages(
+      @NonNull TopicId topicId, @NonNull java.time.Instant after) throws HieroException {
+    Objects.requireNonNull(topicId, "topicId must not be null");
+    Objects.requireNonNull(after, "after must not be null");
+    final String path = "/api/v1/topics/" + topicId + "/messages?timestamp=gt:" + formatInstant(after);
+    final Function<JsonObject, List<TopicMessage>> dataExtractionFunction =
+        node -> jsonConverter.toTopicMessages(node);
+    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+  }
+
+  private String formatInstant(java.time.Instant instant) {
+    return instant.getEpochSecond() + "." + String.format("%09d", instant.getNano());
   }
 
   @Override

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -77,7 +77,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
       @NonNull AccountId accountId, @NonNull Instant after) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(after, "after must not be null");
-    final String path = "/api/v1/transactions?account.id=" + accountId + "&timestamp=gt:" + formatInstant(after);
+    final String path =
+        "/api/v1/transactions?account.id=" + accountId + "&timestamp=gt:" + formatInstant(after);
     final Function<JsonObject, List<TransactionInfo>> dataExtractionFunction =
         node -> jsonConverter.toTransactionInfos(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
@@ -159,7 +160,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
       @NonNull TopicId topicId, @NonNull Instant after) throws HieroException {
     Objects.requireNonNull(topicId, "topicId must not be null");
     Objects.requireNonNull(after, "after must not be null");
-    final String path = "/api/v1/topics/" + topicId + "/messages?timestamp=gt:" + formatInstant(after);
+    final String path =
+        "/api/v1/topics/" + topicId + "/messages?timestamp=gt:" + formatInstant(after);
     final Function<JsonObject, List<TopicMessage>> dataExtractionFunction =
         node -> jsonConverter.toTopicMessages(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -4,6 +4,7 @@ import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
 import jakarta.json.JsonObject;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -73,7 +74,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
   @Override
   public @NonNull Page<TransactionInfo> queryTransactionsByAccount(
-      @NonNull AccountId accountId, @NonNull java.time.Instant after) throws HieroException {
+      @NonNull AccountId accountId, @NonNull Instant after) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(after, "after must not be null");
     final String path = "/api/v1/transactions?account.id=" + accountId + "&timestamp=gt:" + formatInstant(after);
@@ -155,7 +156,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
   @Override
   public @NonNull Page<TopicMessage> queryTopicMessages(
-      @NonNull TopicId topicId, @NonNull java.time.Instant after) throws HieroException {
+      @NonNull TopicId topicId, @NonNull Instant after) throws HieroException {
     Objects.requireNonNull(topicId, "topicId must not be null");
     Objects.requireNonNull(after, "after must not be null");
     final String path = "/api/v1/topics/" + topicId + "/messages?timestamp=gt:" + formatInstant(after);
@@ -164,7 +165,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
   }
 
-  private String formatInstant(java.time.Instant instant) {
+  private String formatInstant(Instant instant) {
     return instant.getEpochSecond() + "." + String.format("%09d", instant.getNano());
   }
 

--- a/hiero-enterprise-spring-sample/src/main/java/org/hiero/spring/sample/HieroEventListener.java
+++ b/hiero-enterprise-spring-sample/src/main/java/org/hiero/spring/sample/HieroEventListener.java
@@ -1,0 +1,34 @@
+package org.hiero.spring.sample;
+
+import org.hiero.base.data.TransactionInfo;
+import org.hiero.base.data.TopicMessage;
+import org.hiero.spring.annotation.HieroTransactionListener;
+import org.hiero.spring.annotation.HieroTopicListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HieroEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(HieroEventListener.class);
+
+    /**
+     * Listen for transactions on a specific account.
+     * Note: In a real app, this would be an account you care about (e.g., your treasury).
+     */
+    @HieroTransactionListener(account = "0.0.1234", interval = 10000)
+    public void onTransaction(TransactionInfo tx) {
+        log.info(">>> [Hiero Event] New transaction detected: {} (Status: {})", 
+                 tx.transactionId(), tx.status());
+    }
+
+    /**
+     * Listen for messages on a specific HCS topic.
+     */
+    @HieroTopicListener(topicId = "0.0.5678", interval = 5000)
+    public void onTopicMessage(TopicMessage msg) {
+        log.info(">>> [Hiero Event] New message on topic {}: {}", 
+                 msg.topicId(), msg.message());
+    }
+}

--- a/hiero-enterprise-spring-sample/src/main/java/org/hiero/spring/sample/HieroEventListener.java
+++ b/hiero-enterprise-spring-sample/src/main/java/org/hiero/spring/sample/HieroEventListener.java
@@ -19,8 +19,8 @@ public class HieroEventListener {
      */
     @HieroTransactionListener(account = "0.0.1234", interval = 10000)
     public void onTransaction(TransactionInfo tx) {
-        log.info(">>> [Hiero Event] New transaction detected: {} (Status: {})", 
-                 tx.transactionId(), tx.status());
+        log.info(">>> [Hiero Event] New transaction detected: {} (Result: {})", 
+                 tx.transactionId(), tx.result());
     }
 
     /**

--- a/hiero-enterprise-spring-sample/src/main/java/org/hiero/spring/sample/HieroEventListener.java
+++ b/hiero-enterprise-spring-sample/src/main/java/org/hiero/spring/sample/HieroEventListener.java
@@ -1,9 +1,9 @@
 package org.hiero.spring.sample;
 
-import org.hiero.base.data.TransactionInfo;
 import org.hiero.base.data.TopicMessage;
-import org.hiero.spring.annotation.HieroTransactionListener;
+import org.hiero.base.data.TransactionInfo;
 import org.hiero.spring.annotation.HieroTopicListener;
+import org.hiero.spring.annotation.HieroTransactionListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -11,24 +11,23 @@ import org.springframework.stereotype.Component;
 @Component
 public class HieroEventListener {
 
-    private static final Logger log = LoggerFactory.getLogger(HieroEventListener.class);
+  private static final Logger log = LoggerFactory.getLogger(HieroEventListener.class);
 
-    /**
-     * Listen for transactions on a specific account.
-     * Note: In a real app, this would be an account you care about (e.g., your treasury).
-     */
-    @HieroTransactionListener(account = "0.0.1234", interval = 10000)
-    public void onTransaction(TransactionInfo tx) {
-        log.info(">>> [Hiero Event] New transaction detected: {} (Result: {})", 
-                 tx.transactionId(), tx.result());
-    }
+  /**
+   * Listen for transactions on a specific account. Note: In a real app, this would be an account
+   * you care about (e.g., your treasury).
+   */
+  @HieroTransactionListener(account = "0.0.1234", interval = 10000)
+  public void onTransaction(TransactionInfo tx) {
+    log.info(
+        ">>> [Hiero Event] New transaction detected: {} (Result: {})",
+        tx.transactionId(),
+        tx.result());
+  }
 
-    /**
-     * Listen for messages on a specific HCS topic.
-     */
-    @HieroTopicListener(topicId = "0.0.5678", interval = 5000)
-    public void onTopicMessage(TopicMessage msg) {
-        log.info(">>> [Hiero Event] New message on topic {}: {}", 
-                 msg.topicId(), msg.message());
-    }
+  /** Listen for messages on a specific HCS topic. */
+  @HieroTopicListener(topicId = "0.0.5678", interval = 5000)
+  public void onTopicMessage(TopicMessage msg) {
+    log.info(">>> [Hiero Event] New message on topic {}: {}", msg.topicId(), msg.message());
+  }
 }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/annotation/HieroTopicListener.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/annotation/HieroTopicListener.java
@@ -21,17 +21,17 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HieroTopicListener {
 
-    /**
-     * The topic ID to monitor for messages.
-     *
-     * @return the topic ID (e.g., "0.0.5678").
-     */
-    String topicId();
+  /**
+   * The topic ID to monitor for messages.
+   *
+   * @return the topic ID (e.g., "0.0.5678").
+   */
+  String topicId();
 
-    /**
-     * Polling interval in milliseconds. Defaults to 5000ms (5 seconds).
-     *
-     * @return the polling interval.
-     */
-    long interval() default 5000;
+  /**
+   * Polling interval in milliseconds. Defaults to 5000ms (5 seconds).
+   *
+   * @return the polling interval.
+   */
+  long interval() default 5000;
 }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/annotation/HieroTopicListener.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/annotation/HieroTopicListener.java
@@ -1,0 +1,37 @@
+package org.hiero.spring.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that marks a method as a listener for Hiero Consensus Service (HCS) messages.
+ *
+ * <p>The annotated method should accept a single parameter of type {@code TopicMessage}.
+ *
+ * <pre>{@code
+ * @HieroTopicListener(topicId = "0.0.5678")
+ * public void onMessage(TopicMessage msg) {
+ *     log.info("Received message: {}", msg.message());
+ * }
+ * }</pre>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HieroTopicListener {
+
+    /**
+     * The topic ID to monitor for messages.
+     *
+     * @return the topic ID (e.g., "0.0.5678").
+     */
+    String topicId();
+
+    /**
+     * Polling interval in milliseconds. Defaults to 5000ms (5 seconds).
+     *
+     * @return the polling interval.
+     */
+    long interval() default 5000;
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/annotation/HieroTransactionListener.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/annotation/HieroTransactionListener.java
@@ -1,0 +1,38 @@
+package org.hiero.spring.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * Annotation that marks a method as a listener for Hiero network transactions.
+ *
+ * <p>The annotated method should accept a single parameter of type {@code TransactionInfo}.
+ *
+ * <pre>{@code
+ * @HieroTransactionListener(account = "0.0.1234")
+ * public void onTransfer(TransactionInfo tx) {
+ *     log.info("Received transaction: {}", tx.transactionId());
+ * }
+ * }</pre>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HieroTransactionListener {
+
+    /**
+     * The account ID to monitor for transactions.
+     *
+     * @return the account ID (e.g., "0.0.1234").
+     */
+    String account();
+
+    /**
+     * Polling interval in milliseconds. Defaults to 5000ms (5 seconds).
+     *
+     * @return the polling interval.
+     */
+    long interval() default 5000;
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/annotation/HieroTransactionListener.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/annotation/HieroTransactionListener.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.core.annotation.AliasFor;
 
 /**
  * Annotation that marks a method as a listener for Hiero network transactions.
@@ -22,17 +21,17 @@ import org.springframework.core.annotation.AliasFor;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HieroTransactionListener {
 
-    /**
-     * The account ID to monitor for transactions.
-     *
-     * @return the account ID (e.g., "0.0.1234").
-     */
-    String account();
+  /**
+   * The account ID to monitor for transactions.
+   *
+   * @return the account ID (e.g., "0.0.1234").
+   */
+  String account();
 
-    /**
-     * Polling interval in milliseconds. Defaults to 5000ms (5 seconds).
-     *
-     * @return the polling interval.
-     */
-    long interval() default 5000;
+  /**
+   * Polling interval in milliseconds. Defaults to 5000ms (5 seconds).
+   *
+   * @return the polling interval.
+   */
+  long interval() default 5000;
 }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -129,9 +129,9 @@ public class HieroAutoConfiguration {
       final String mirrorNodeEndpointProtocol = url.getProtocol();
       final String mirrorNodeEndpointHost = url.getHost();
       final int mirrorNodeEndpointPort;
-      if (mirrorNodeEndpointProtocol == "https" && url.getPort() == -1) {
+      if (mirrorNodeEndpointProtocol.equals("https") && url.getPort() == -1) {
         mirrorNodeEndpointPort = 443;
-      } else if (mirrorNodeEndpointProtocol == "http" && url.getPort() == -1) {
+      } else if (mirrorNodeEndpointProtocol.equals("http") && url.getPort() == -1) {
         mirrorNodeEndpointPort = 80;
       } else if (url.getPort() == -1) {
         mirrorNodeEndpointPort = 443;

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -226,4 +226,15 @@ public class HieroAutoConfiguration {
   ContractVerificationClient contractVerificationClient(final HieroConfig hieroConfig) {
     return new ContractVerificationClientImplementation(hieroConfig);
   }
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "spring.hiero",
+      name = "mirrorNodeSupported",
+      havingValue = "true",
+      matchIfMissing = true)
+  HieroListenerProcessor hieroListenerProcessor(
+      final TransactionRepository transactionRepository, final TopicRepository topicRepository) {
+    return new HieroListenerProcessor(transactionRepository, topicRepository);
+  }
 }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroListenerProcessor.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroListenerProcessor.java
@@ -1,0 +1,113 @@
+package org.hiero.spring.implementation;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.TopicId;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.hiero.base.mirrornode.TopicRepository;
+import org.hiero.base.mirrornode.TransactionRepository;
+import org.hiero.base.observer.AbstractPollingObserver;
+import org.hiero.base.observer.TopicObserver;
+import org.hiero.base.observer.TransactionObserver;
+import org.hiero.spring.annotation.HieroTopicListener;
+import org.hiero.spring.annotation.HieroTransactionListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Processor that scans Spring beans for {@link HieroTransactionListener} and
+ * {@link HieroTopicListener} annotations and manages the corresponding observers.
+ */
+public class HieroListenerProcessor implements BeanPostProcessor, SmartLifecycle {
+
+    private static final Logger log = LoggerFactory.getLogger(HieroListenerProcessor.class);
+
+    private final TransactionRepository transactionRepository;
+    private final TopicRepository topicRepository;
+    private final List<AbstractPollingObserver<?>> observers = new ArrayList<>();
+    private boolean running = false;
+
+    public HieroListenerProcessor(TransactionRepository transactionRepository, TopicRepository topicRepository) {
+        this.transactionRepository = transactionRepository;
+        this.topicRepository = topicRepository;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        ReflectionUtils.doWithMethods(bean.getClass(), method -> {
+            if (method.isAnnotationPresent(HieroTransactionListener.class)) {
+                processTransactionListener(bean, method);
+            }
+            if (method.isAnnotationPresent(HieroTopicListener.class)) {
+                processTopicListener(bean, method);
+            }
+        });
+        return bean;
+    }
+
+    private void processTransactionListener(Object bean, Method method) {
+        HieroTransactionListener annotation = method.getAnnotation(HieroTransactionListener.class);
+        log.info("Registering transaction listener for account {} on method {}", annotation.account(), method.getName());
+
+        TransactionObserver observer = new TransactionObserver(
+                transactionRepository,
+                AccountId.fromString(annotation.account()),
+                Duration.ofMillis(annotation.interval()),
+                event -> invokeMethod(bean, method, event)
+        );
+        observers.add(observer);
+        if (running) {
+            observer.start();
+        }
+    }
+
+    private void processTopicListener(Object bean, Method method) {
+        HieroTopicListener annotation = method.getAnnotation(HieroTopicListener.class);
+        log.info("Registering topic listener for topic {} on method {}", annotation.topicId(), method.getName());
+
+        TopicObserver observer = new TopicObserver(
+                topicRepository,
+                TopicId.fromString(annotation.topicId()),
+                Duration.ofMillis(annotation.interval()),
+                event -> invokeMethod(bean, method, event)
+        );
+        observers.add(observer);
+        if (running) {
+            observer.start();
+        }
+    }
+
+    private void invokeMethod(Object bean, Method method, Object event) {
+        try {
+            ReflectionUtils.makeAccessible(method);
+            method.invoke(bean, event);
+        } catch (Exception e) {
+            log.error("Failed to invoke Hiero listener method {}", method.getName(), e);
+        }
+    }
+
+    @Override
+    public void start() {
+        log.info("Starting Hiero listener observers...");
+        observers.forEach(AbstractPollingObserver::start);
+        this.running = true;
+    }
+
+    @Override
+    public void stop() {
+        log.info("Stopping Hiero listener observers...");
+        observers.forEach(AbstractPollingObserver::stop);
+        this.running = false;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroListenerProcessor.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroListenerProcessor.java
@@ -15,9 +15,12 @@ import org.hiero.spring.annotation.HieroTopicListener;
 import org.hiero.spring.annotation.HieroTransactionListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.SmartLifecycle;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.ReflectionUtils;
 
 /**
@@ -30,17 +33,29 @@ public class HieroListenerProcessor implements BeanPostProcessor, SmartLifecycle
 
     private final TransactionRepository transactionRepository;
     private final TopicRepository topicRepository;
+    private final TaskScheduler taskScheduler;
     private final List<AbstractPollingObserver<?>> observers = new ArrayList<>();
     private boolean running = false;
 
     public HieroListenerProcessor(TransactionRepository transactionRepository, TopicRepository topicRepository) {
         this.transactionRepository = transactionRepository;
         this.topicRepository = topicRepository;
+        this.taskScheduler = createDefaultTaskScheduler();
+    }
+
+    private TaskScheduler createDefaultTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(Runtime.getRuntime().availableProcessors());
+        scheduler.setThreadNamePrefix("hiero-observer-");
+        scheduler.setDaemon(true);
+        scheduler.initialize();
+        return scheduler;
     }
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        ReflectionUtils.doWithMethods(bean.getClass(), method -> {
+        Class<?> targetClass = AopProxyUtils.ultimateTargetClass(bean);
+        ReflectionUtils.doWithMethods(targetClass, method -> {
             if (method.isAnnotationPresent(HieroTransactionListener.class)) {
                 processTransactionListener(bean, method);
             }
@@ -56,6 +71,7 @@ public class HieroListenerProcessor implements BeanPostProcessor, SmartLifecycle
         log.info("Registering transaction listener for account {} on method {}", annotation.account(), method.getName());
 
         TransactionObserver observer = new TransactionObserver(
+                ((ThreadPoolTaskScheduler) taskScheduler).getScheduledExecutor(),
                 transactionRepository,
                 AccountId.fromString(annotation.account()),
                 Duration.ofMillis(annotation.interval()),
@@ -72,6 +88,7 @@ public class HieroListenerProcessor implements BeanPostProcessor, SmartLifecycle
         log.info("Registering topic listener for topic {} on method {}", annotation.topicId(), method.getName());
 
         TopicObserver observer = new TopicObserver(
+                ((ThreadPoolTaskScheduler) taskScheduler).getScheduledExecutor(),
                 topicRepository,
                 TopicId.fromString(annotation.topicId()),
                 Duration.ofMillis(annotation.interval()),

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroListenerProcessor.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroListenerProcessor.java
@@ -24,107 +24,116 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.ReflectionUtils;
 
 /**
- * Processor that scans Spring beans for {@link HieroTransactionListener} and
- * {@link HieroTopicListener} annotations and manages the corresponding observers.
+ * Processor that scans Spring beans for {@link HieroTransactionListener} and {@link
+ * HieroTopicListener} annotations and manages the corresponding observers.
  */
 public class HieroListenerProcessor implements BeanPostProcessor, SmartLifecycle {
 
-    private static final Logger log = LoggerFactory.getLogger(HieroListenerProcessor.class);
+  private static final Logger log = LoggerFactory.getLogger(HieroListenerProcessor.class);
 
-    private final TransactionRepository transactionRepository;
-    private final TopicRepository topicRepository;
-    private final TaskScheduler taskScheduler;
-    private final List<AbstractPollingObserver<?>> observers = new ArrayList<>();
-    private boolean running = false;
+  private final TransactionRepository transactionRepository;
+  private final TopicRepository topicRepository;
+  private final TaskScheduler taskScheduler;
+  private final List<AbstractPollingObserver<?>> observers = new ArrayList<>();
+  private boolean running = false;
 
-    public HieroListenerProcessor(TransactionRepository transactionRepository, TopicRepository topicRepository) {
-        this.transactionRepository = transactionRepository;
-        this.topicRepository = topicRepository;
-        this.taskScheduler = createDefaultTaskScheduler();
-    }
+  public HieroListenerProcessor(
+      TransactionRepository transactionRepository, TopicRepository topicRepository) {
+    this.transactionRepository = transactionRepository;
+    this.topicRepository = topicRepository;
+    this.taskScheduler = createDefaultTaskScheduler();
+  }
 
-    private TaskScheduler createDefaultTaskScheduler() {
-        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(Runtime.getRuntime().availableProcessors());
-        scheduler.setThreadNamePrefix("hiero-observer-");
-        scheduler.setDaemon(true);
-        scheduler.initialize();
-        return scheduler;
-    }
+  private TaskScheduler createDefaultTaskScheduler() {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setPoolSize(Runtime.getRuntime().availableProcessors());
+    scheduler.setThreadNamePrefix("hiero-observer-");
+    scheduler.setDaemon(true);
+    scheduler.initialize();
+    return scheduler;
+  }
 
-    @Override
-    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        Class<?> targetClass = AopProxyUtils.ultimateTargetClass(bean);
-        ReflectionUtils.doWithMethods(targetClass, method -> {
-            if (method.isAnnotationPresent(HieroTransactionListener.class)) {
-                processTransactionListener(bean, method);
-            }
-            if (method.isAnnotationPresent(HieroTopicListener.class)) {
-                processTopicListener(bean, method);
-            }
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    Class<?> targetClass = AopProxyUtils.ultimateTargetClass(bean);
+    ReflectionUtils.doWithMethods(
+        targetClass,
+        method -> {
+          if (method.isAnnotationPresent(HieroTransactionListener.class)) {
+            processTransactionListener(bean, method);
+          }
+          if (method.isAnnotationPresent(HieroTopicListener.class)) {
+            processTopicListener(bean, method);
+          }
         });
-        return bean;
+    return bean;
+  }
+
+  private void processTransactionListener(Object bean, Method method) {
+    HieroTransactionListener annotation = method.getAnnotation(HieroTransactionListener.class);
+    log.info(
+        "Registering transaction listener for account {} on method {}",
+        annotation.account(),
+        method.getName());
+
+    TransactionObserver observer =
+        new TransactionObserver(
+            ((ThreadPoolTaskScheduler) taskScheduler).getScheduledExecutor(),
+            transactionRepository,
+            AccountId.fromString(annotation.account()),
+            Duration.ofMillis(annotation.interval()),
+            event -> invokeMethod(bean, method, event));
+    observers.add(observer);
+    if (running) {
+      observer.start();
     }
+  }
 
-    private void processTransactionListener(Object bean, Method method) {
-        HieroTransactionListener annotation = method.getAnnotation(HieroTransactionListener.class);
-        log.info("Registering transaction listener for account {} on method {}", annotation.account(), method.getName());
+  private void processTopicListener(Object bean, Method method) {
+    HieroTopicListener annotation = method.getAnnotation(HieroTopicListener.class);
+    log.info(
+        "Registering topic listener for topic {} on method {}",
+        annotation.topicId(),
+        method.getName());
 
-        TransactionObserver observer = new TransactionObserver(
-                ((ThreadPoolTaskScheduler) taskScheduler).getScheduledExecutor(),
-                transactionRepository,
-                AccountId.fromString(annotation.account()),
-                Duration.ofMillis(annotation.interval()),
-                event -> invokeMethod(bean, method, event)
-        );
-        observers.add(observer);
-        if (running) {
-            observer.start();
-        }
+    TopicObserver observer =
+        new TopicObserver(
+            ((ThreadPoolTaskScheduler) taskScheduler).getScheduledExecutor(),
+            topicRepository,
+            TopicId.fromString(annotation.topicId()),
+            Duration.ofMillis(annotation.interval()),
+            event -> invokeMethod(bean, method, event));
+    observers.add(observer);
+    if (running) {
+      observer.start();
     }
+  }
 
-    private void processTopicListener(Object bean, Method method) {
-        HieroTopicListener annotation = method.getAnnotation(HieroTopicListener.class);
-        log.info("Registering topic listener for topic {} on method {}", annotation.topicId(), method.getName());
-
-        TopicObserver observer = new TopicObserver(
-                ((ThreadPoolTaskScheduler) taskScheduler).getScheduledExecutor(),
-                topicRepository,
-                TopicId.fromString(annotation.topicId()),
-                Duration.ofMillis(annotation.interval()),
-                event -> invokeMethod(bean, method, event)
-        );
-        observers.add(observer);
-        if (running) {
-            observer.start();
-        }
+  private void invokeMethod(Object bean, Method method, Object event) {
+    try {
+      ReflectionUtils.makeAccessible(method);
+      method.invoke(bean, event);
+    } catch (Exception e) {
+      log.error("Failed to invoke Hiero listener method {}", method.getName(), e);
     }
+  }
 
-    private void invokeMethod(Object bean, Method method, Object event) {
-        try {
-            ReflectionUtils.makeAccessible(method);
-            method.invoke(bean, event);
-        } catch (Exception e) {
-            log.error("Failed to invoke Hiero listener method {}", method.getName(), e);
-        }
-    }
+  @Override
+  public void start() {
+    log.info("Starting Hiero listener observers...");
+    observers.forEach(AbstractPollingObserver::start);
+    this.running = true;
+  }
 
-    @Override
-    public void start() {
-        log.info("Starting Hiero listener observers...");
-        observers.forEach(AbstractPollingObserver::start);
-        this.running = true;
-    }
+  @Override
+  public void stop() {
+    log.info("Stopping Hiero listener observers...");
+    observers.forEach(AbstractPollingObserver::stop);
+    this.running = false;
+  }
 
-    @Override
-    public void stop() {
-        log.info("Stopping Hiero listener observers...");
-        observers.forEach(AbstractPollingObserver::stop);
-        this.running = false;
-    }
-
-    @Override
-    public boolean isRunning() {
-        return running;
-    }
+  @Override
+  public boolean isRunning() {
+    return running;
+  }
 }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
@@ -98,6 +98,18 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
   }
 
   @Override
+  public Page<TransactionInfo> queryTransactionsByAccount(
+      @NonNull AccountId accountId, @NonNull java.time.Instant after) throws HieroException {
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    Objects.requireNonNull(after, "after must not be null");
+    final String path = "/api/v1/transactions?account.id=" + accountId + "&timestamp=gt:" + formatInstant(after);
+    final Function<JsonNode, List<TransactionInfo>> dataExtractionFunction =
+        n -> jsonConverter.toTransactionInfos(n);
+    return new RestBasedPage<>(
+        objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
+  }
+
+  @Override
   public @NonNull Page<TransactionInfo> queryTransactionsByAccountAndType(
       @NonNull AccountId accountId, @NonNull TransactionType type) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
@@ -171,6 +183,22 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
         node -> jsonConverter.toTopicMessages(node);
     return new RestBasedPage<>(
         objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
+  }
+
+  @Override
+  public @NonNull Page<TopicMessage> queryTopicMessages(@NonNull TopicId topicId, @NonNull java.time.Instant after)
+      throws HieroException {
+    Objects.requireNonNull(topicId, "topicId must not be null");
+    Objects.requireNonNull(after, "after must not be null");
+    final String path = "/api/v1/topics/" + topicId + "/messages?timestamp=gt:" + formatInstant(after);
+    final Function<JsonNode, List<TopicMessage>> dataExtractionFunction =
+        node -> jsonConverter.toTopicMessages(node);
+    return new RestBasedPage<>(
+        objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
+  }
+
+  private String formatInstant(java.time.Instant instant) {
+    return instant.getEpochSecond() + "." + String.format("%09d", instant.getNano());
   }
 
   @Override

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
@@ -103,7 +103,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
       @NonNull AccountId accountId, @NonNull Instant after) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(after, "after must not be null");
-    final String path = "/api/v1/transactions?account.id=" + accountId + "&timestamp=gt:" + formatInstant(after);
+    final String path =
+        "/api/v1/transactions?account.id=" + accountId + "&timestamp=gt:" + formatInstant(after);
     final Function<JsonNode, List<TransactionInfo>> dataExtractionFunction =
         n -> jsonConverter.toTransactionInfos(n);
     return new RestBasedPage<>(
@@ -187,11 +188,12 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
   }
 
   @Override
-  public @NonNull Page<TopicMessage> queryTopicMessages(@NonNull TopicId topicId, @NonNull Instant after)
-      throws HieroException {
+  public @NonNull Page<TopicMessage> queryTopicMessages(
+      @NonNull TopicId topicId, @NonNull Instant after) throws HieroException {
     Objects.requireNonNull(topicId, "topicId must not be null");
     Objects.requireNonNull(after, "after must not be null");
-    final String path = "/api/v1/topics/" + topicId + "/messages?timestamp=gt:" + formatInstant(after);
+    final String path =
+        "/api/v1/topics/" + topicId + "/messages?timestamp=gt:" + formatInstant(after);
     final Function<JsonNode, List<TopicMessage>> dataExtractionFunction =
         node -> jsonConverter.toTopicMessages(node);
     return new RestBasedPage<>(

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -99,7 +100,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
 
   @Override
   public Page<TransactionInfo> queryTransactionsByAccount(
-      @NonNull AccountId accountId, @NonNull java.time.Instant after) throws HieroException {
+      @NonNull AccountId accountId, @NonNull Instant after) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(after, "after must not be null");
     final String path = "/api/v1/transactions?account.id=" + accountId + "&timestamp=gt:" + formatInstant(after);
@@ -186,7 +187,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
   }
 
   @Override
-  public @NonNull Page<TopicMessage> queryTopicMessages(@NonNull TopicId topicId, @NonNull java.time.Instant after)
+  public @NonNull Page<TopicMessage> queryTopicMessages(@NonNull TopicId topicId, @NonNull Instant after)
       throws HieroException {
     Objects.requireNonNull(topicId, "topicId must not be null");
     Objects.requireNonNull(after, "after must not be null");
@@ -197,7 +198,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
         objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
   }
 
-  private String formatInstant(java.time.Instant instant) {
+  private String formatInstant(Instant instant) {
     return instant.getEpochSecond() + "." + String.format("%09d", instant.getNano());
   }
 


### PR DESCRIPTION
**Description**:
This PR implements a declarative, annotation-driven Event Observer Framework to enable reactive monitoring of Hiero network transactions and HCS topic messages.

* Implement `AbstractPollingObserver` core engine for stable, background network monitoring.
* Add `@HieroTransactionListener` and `@HieroTopicListener` annotations for high-level event subscription.
* Introduce `HieroListenerProcessor` for automatic bean discovery and lifecycle management in Spring Boot.
* Extend `MirrorNodeClient` and Repository layers with timestamp-based filtering support.
* Add deduplication logic to ensure exact-once delivery of network events.
* Provide a working demonstration in the `hiero-enterprise-spring-sample` module.

**Related issue(s)**:

Fixes #81

**Notes for reviewer**:
The framework uses a polling-based approach against the Mirror Node REST API, which provides better stability for long-running observers in enterprise environments compared to raw gRPC streams. 

I've verified the implementation by adding a sample listener in the `spring-sample` app (see `HieroEventListener.java`). Below is a snippet of how a developer would use this new functionality:

```java
@HieroTopicListener(topicId = "0.0.5678", interval = 5000)
public void handleMessages(TopicMessage msg) {
    log.info("New message received: {}", msg.message());
}
\```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
