### PR TITLE
feat(microprofile): implement NFT mirror-node queries

### DIFF
--- a/hiero-enterprise-microprofile/pom.xml
+++ b/hiero-enterprise-microprofile/pom.xml
@@ -82,5 +82,10 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -25,10 +25,9 @@ import org.jspecify.annotations.NonNull;
 
 public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
-  private static final String ACCOUNTS_PATH = "/api/v1/accounts";
   private static final String TOKENS_PATH = "/api/v1/tokens";
+  private static final String ACCOUNTS_PATH = "/api/v1/accounts";
   private static final String NFTS_PATH = "/nfts";
-  private static final String ACCOUNT_ID_QUERY = "?account.id=";
 
   private final MirrorNodeRestClientImpl restClient;
 
@@ -64,7 +63,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
       @NonNull AccountId accountId, @NonNull TokenId tokenId) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(tokenId, "tokenId must not be null");
-    final String path = TOKENS_PATH + "/" + tokenId + NFTS_PATH + ACCOUNT_ID_QUERY + accountId;
+    final String path = TOKENS_PATH + "/" + tokenId + NFTS_PATH + "?account.id=" + accountId;
     final Function<JsonObject, List<Nft>> dataExtractionFunction =
         node -> jsonConverter.toNfts(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -25,10 +25,6 @@ import org.jspecify.annotations.NonNull;
 
 public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
-  private static final String TOKENS_PATH = "/api/v1/tokens";
-  private static final String ACCOUNTS_PATH = "/api/v1/accounts";
-  private static final String NFTS_PATH = "/nfts";
-
   private final MirrorNodeRestClientImpl restClient;
 
   private final MirrorNodeJsonConverter<JsonObject> jsonConverter;
@@ -52,7 +48,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
   @Override
   public @NonNull Page<Nft> queryNftsByAccount(@NonNull AccountId accountId) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    final String path = ACCOUNTS_PATH + "/" + accountId + NFTS_PATH;
+    final String path = "/api/v1/accounts/" + accountId + "/nfts";
     final Function<JsonObject, List<Nft>> dataExtractionFunction =
         node -> jsonConverter.toNfts(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
@@ -63,7 +59,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
       @NonNull AccountId accountId, @NonNull TokenId tokenId) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(tokenId, "tokenId must not be null");
-    final String path = TOKENS_PATH + "/" + tokenId + NFTS_PATH + "?account.id=" + accountId;
+    final String path = "/api/v1/tokens/" + tokenId + "/nfts?account.id=" + accountId;
     final Function<JsonObject, List<Nft>> dataExtractionFunction =
         node -> jsonConverter.toNfts(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
@@ -72,7 +68,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
   @Override
   public @NonNull Page<Nft> queryNftsByTokenId(@NonNull TokenId tokenId) throws HieroException {
     Objects.requireNonNull(tokenId, "tokenId must not be null");
-    final String path = TOKENS_PATH + "/" + tokenId + NFTS_PATH;
+    final String path = "/api/v1/tokens/" + tokenId + "/nfts";
     final Function<JsonObject, List<Nft>> dataExtractionFunction =
         node -> jsonConverter.toNfts(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -25,6 +25,11 @@ import org.jspecify.annotations.NonNull;
 
 public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
+  private static final String ACCOUNTS_PATH = "/api/v1/accounts";
+  private static final String TOKENS_PATH = "/api/v1/tokens";
+  private static final String NFTS_PATH = "/nfts";
+  private static final String ACCOUNT_ID_QUERY = "?account.id=";
+
   private final MirrorNodeRestClientImpl restClient;
 
   private final MirrorNodeJsonConverter<JsonObject> jsonConverter;
@@ -47,18 +52,31 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
   @Override
   public @NonNull Page<Nft> queryNftsByAccount(@NonNull AccountId accountId) throws HieroException {
-    throw new RuntimeException("Not implemented");
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    final String path = ACCOUNTS_PATH + "/" + accountId + NFTS_PATH;
+    final Function<JsonObject, List<Nft>> dataExtractionFunction =
+        node -> jsonConverter.toNfts(node);
+    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
   public @NonNull Page<Nft> queryNftsByAccountAndTokenId(
       @NonNull AccountId accountId, @NonNull TokenId tokenId) throws HieroException {
-    throw new RuntimeException("Not implemented");
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    Objects.requireNonNull(tokenId, "tokenId must not be null");
+    final String path = TOKENS_PATH + "/" + tokenId + NFTS_PATH + ACCOUNT_ID_QUERY + accountId;
+    final Function<JsonObject, List<Nft>> dataExtractionFunction =
+        node -> jsonConverter.toNfts(node);
+    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
   public @NonNull Page<Nft> queryNftsByTokenId(@NonNull TokenId tokenId) throws HieroException {
-    throw new RuntimeException("Not implemented");
+    Objects.requireNonNull(tokenId, "tokenId must not be null");
+    final String path = TOKENS_PATH + "/" + tokenId + NFTS_PATH;
+    final Function<JsonObject, List<Nft>> dataExtractionFunction =
+        node -> jsonConverter.toNfts(node);
+    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
@@ -58,7 +58,7 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
       final TokenId parsedTokenId = TokenId.fromString(jsonObject.getString("token_id"));
       final AccountId account = AccountId.fromString(jsonObject.getString("account_id"));
       final long serial = jsonObject.getJsonNumber("serial_number").longValue();
-      final byte[] metadata = jsonObject.getString("metadata").getBytes();
+      final byte[] metadata = Base64.getDecoder().decode(jsonObject.getString("metadata"));
       return Optional.of(new Nft(parsedTokenId, serial, account, metadata));
     } catch (final Exception e) {
       throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
@@ -336,12 +336,12 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
 
   @Override
   public List<Nft> toNfts(@NonNull JsonObject jsonObject) {
-    if (!jsonObject.containsKey("transactions")) {
+    if (!jsonObject.containsKey("nfts")) {
       return List.of();
     }
 
     final JsonArray nftsArray = jsonObject.getJsonArray("nfts");
-    if (nftsArray.isEmpty()) {
+    if (nftsArray == null) {
       throw new IllegalArgumentException("NFTs jsonObject is not an array: " + nftsArray);
     }
     Spliterator<JsonValue> spliterator =

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeClientImplNftTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeClientImplNftTest.java
@@ -1,0 +1,162 @@
+package org.hiero.microprofile.test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.base.HieroException;
+import org.hiero.base.data.Nft;
+import org.hiero.base.data.Page;
+import org.hiero.microprofile.implementation.MirrorNodeClientImpl;
+import org.hiero.microprofile.implementation.MirrorNodeJsonConverterImpl;
+import org.hiero.microprofile.implementation.MirrorNodeRestClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MirrorNodeClientImplNftTest {
+
+  private static final String HOST = "127.0.0.1";
+  private static final String ACCOUNT_NFTS_PATH = "/api/v1/accounts/0.0.1001/nfts";
+  private static final String TOKEN_NFTS_PATH = "/api/v1/tokens/0.0.2002/nfts";
+  private static final String TOKEN_NFTS_FOR_ACCOUNT_PATH =
+      TOKEN_NFTS_PATH + "?account.id=0.0.1001";
+  private static final String EMPTY_NFTS_RESPONSE = "{\"nfts\":[],\"links\":{\"next\":null}}";
+  private static final String NFT_METADATA = "test NFT";
+  private static final String NFT_METADATA_BASE64 = "dGVzdCBORlQ=";
+  private static final String CONTENT_TYPE_HEADER = "Content-Type";
+  private static final String APPLICATION_JSON = "application/json";
+
+  private HttpServer server;
+  private String baseUrl;
+  private final AtomicReference<String> lastRequestedPath = new AtomicReference<>();
+
+  @BeforeEach
+  void startServer() throws IOException {
+    server = HttpServer.create(new InetSocketAddress(HOST, 0), 0);
+    server.setExecutor(null);
+    server.start();
+    baseUrl = "http://" + HOST + ":" + server.getAddress().getPort();
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void queryNftsByAccountHitsExpectedPath() throws HieroException {
+    respondWith(EMPTY_NFTS_RESPONSE);
+
+    final MirrorNodeClientImpl client = newClient();
+    final Page<Nft> page = client.queryNftsByAccount(AccountId.fromString("0.0.1001"));
+
+    assertNotNull(page);
+    assertEquals(0, page.getSize());
+    assertEquals(ACCOUNT_NFTS_PATH, lastRequestedPath.get());
+  }
+
+  @Test
+  void queryNftsByTokenIdHitsExpectedPath() throws HieroException {
+    respondWith(EMPTY_NFTS_RESPONSE);
+
+    final MirrorNodeClientImpl client = newClient();
+    final Page<Nft> page = client.queryNftsByTokenId(TokenId.fromString("0.0.2002"));
+
+    assertNotNull(page);
+    assertEquals(0, page.getSize());
+    assertEquals(TOKEN_NFTS_PATH, lastRequestedPath.get());
+  }
+
+  @Test
+  void queryNftsByAccountAndTokenIdIncludesAccountFilter() throws HieroException {
+    respondWith(EMPTY_NFTS_RESPONSE);
+
+    final MirrorNodeClientImpl client = newClient();
+    final Page<Nft> page =
+        client.queryNftsByAccountAndTokenId(
+            AccountId.fromString("0.0.1001"), TokenId.fromString("0.0.2002"));
+
+    assertNotNull(page);
+    assertEquals(0, page.getSize());
+    assertEquals(TOKEN_NFTS_FOR_ACCOUNT_PATH, lastRequestedPath.get());
+  }
+
+  @Test
+  void queryNftsByAccountParsesResponse() throws HieroException {
+    final String body =
+        "{\"nfts\":[{"
+            + "\"account_id\":\"0.0.1001\","
+            + "\"created_timestamp\":\"1700000000.000000000\","
+            + "\"modified_timestamp\":\"1700000001.000000000\","
+            + "\"deleted\":false,"
+            + "\"metadata\":\""
+            + NFT_METADATA_BASE64
+            + "\","
+            + "\"serial_number\":1,"
+            + "\"token_id\":\"0.0.2002\""
+            + "}],\"links\":{\"next\":null}}";
+    respondWith(body);
+
+    final MirrorNodeClientImpl client = newClient();
+    final Page<Nft> page = client.queryNftsByAccount(AccountId.fromString("0.0.1001"));
+
+    assertEquals(1, page.getSize());
+    final List<Nft> data = page.getData();
+    assertEquals(TokenId.fromString("0.0.2002"), data.get(0).tokenId());
+    assertEquals(1L, data.get(0).serial());
+    assertArrayEquals(NFT_METADATA.getBytes(StandardCharsets.UTF_8), data.get(0).metadata());
+  }
+
+  @Test
+  void queryNftsByAccountRejectsNullInput() {
+    respondWith(EMPTY_NFTS_RESPONSE);
+
+    final MirrorNodeClientImpl client = newClient();
+    assertThrows(NullPointerException.class, () -> client.queryNftsByAccount((AccountId) null));
+  }
+
+  @Test
+  void queryNftsByTokenIdRejectsNullInput() {
+    respondWith(EMPTY_NFTS_RESPONSE);
+
+    final MirrorNodeClientImpl client = newClient();
+    assertThrows(NullPointerException.class, () -> client.queryNftsByTokenId((TokenId) null));
+  }
+
+  private MirrorNodeClientImpl newClient() {
+    return new MirrorNodeClientImpl(
+        new MirrorNodeRestClientImpl(baseUrl), new MirrorNodeJsonConverterImpl());
+  }
+
+  private void respondWith(final String body) {
+    final HttpHandler handler =
+        new HttpHandler() {
+          @Override
+          public void handle(final HttpExchange exchange) throws IOException {
+            final String path = exchange.getRequestURI().getRawPath();
+            final String query = exchange.getRequestURI().getRawQuery();
+            lastRequestedPath.set(query == null ? path : path + "?" + query);
+            final byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set(CONTENT_TYPE_HEADER, APPLICATION_JSON);
+            exchange.sendResponseHeaders(200, payload.length);
+            exchange.getResponseBody().write(payload);
+            exchange.close();
+          }
+        };
+    server.createContext("/", handler);
+  }
+}

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeClientImplNftTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeClientImplNftTest.java
@@ -4,17 +4,27 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.TokenId;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-import java.io.IOException;
-import java.net.InetSocketAddress;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import org.hiero.base.HieroException;
 import org.hiero.base.data.Nft;
 import org.hiero.base.data.Page;
@@ -24,139 +34,132 @@ import org.hiero.microprofile.implementation.MirrorNodeRestClientImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 class MirrorNodeClientImplNftTest {
 
-  private static final String HOST = "127.0.0.1";
+  private static final String MOCK_TARGET = "http://mock-target";
   private static final String ACCOUNT_NFTS_PATH = "/api/v1/accounts/0.0.1001/nfts";
   private static final String TOKEN_NFTS_PATH = "/api/v1/tokens/0.0.2002/nfts";
-  private static final String TOKEN_NFTS_FOR_ACCOUNT_PATH =
-      TOKEN_NFTS_PATH + "?account.id=0.0.1001";
-  private static final String EMPTY_NFTS_RESPONSE = "{\"nfts\":[],\"links\":{\"next\":null}}";
   private static final String NFT_METADATA = "test NFT";
   private static final String NFT_METADATA_BASE64 = "dGVzdCBORlQ=";
-  private static final String CONTENT_TYPE_HEADER = "Content-Type";
-  private static final String APPLICATION_JSON = "application/json";
+  private static final AccountId ACCOUNT_ID = AccountId.fromString("0.0.1001");
+  private static final TokenId TOKEN_ID = TokenId.fromString("0.0.2002");
 
-  private HttpServer server;
-  private String baseUrl;
-  private final AtomicReference<String> lastRequestedPath = new AtomicReference<>();
+  private final MirrorNodeRestClientImpl restClient = mock(MirrorNodeRestClientImpl.class);
+  private final Client client = mock(Client.class);
+  private final WebTarget webTarget = mock(WebTarget.class);
+  private final Invocation.Builder requestBuilder = mock(Invocation.Builder.class);
+  private final Response response = mock(Response.class);
+  private MockedStatic<ClientBuilder> clientBuilderMock;
 
   @BeforeEach
-  void startServer() throws IOException {
-    server = HttpServer.create(new InetSocketAddress(HOST, 0), 0);
-    server.setExecutor(null);
-    server.start();
-    baseUrl = "http://" + HOST + ":" + server.getAddress().getPort();
+  void setUp() {
+    when(restClient.getTarget()).thenReturn(MOCK_TARGET);
+    clientBuilderMock = mockStatic(ClientBuilder.class);
+    clientBuilderMock.when(ClientBuilder::newClient).thenReturn(client);
+    when(client.target(MOCK_TARGET)).thenReturn(webTarget);
+    when(webTarget.path(anyString())).thenReturn(webTarget);
+    when(webTarget.queryParam(anyString(), any())).thenReturn(webTarget);
+    when(webTarget.request(MediaType.APPLICATION_JSON)).thenReturn(requestBuilder);
+    when(requestBuilder.get()).thenReturn(response);
+    when(response.readEntity(JsonObject.class)).thenReturn(emptyNftsResponse());
   }
 
   @AfterEach
-  void stopServer() {
-    if (server != null) {
-      server.stop(0);
+  void tearDown() {
+    if (clientBuilderMock != null) {
+      clientBuilderMock.close();
     }
   }
 
   @Test
   void queryNftsByAccountHitsExpectedPath() throws HieroException {
-    respondWith(EMPTY_NFTS_RESPONSE);
-
-    final MirrorNodeClientImpl client = newClient();
-    final Page<Nft> page = client.queryNftsByAccount(AccountId.fromString("0.0.1001"));
+    final Page<Nft> page = newClient().queryNftsByAccount(ACCOUNT_ID);
 
     assertNotNull(page);
     assertEquals(0, page.getSize());
-    assertEquals(ACCOUNT_NFTS_PATH, lastRequestedPath.get());
+    verify(client).target(MOCK_TARGET);
+    verify(webTarget).path(ACCOUNT_NFTS_PATH);
+    verify(webTarget, never()).queryParam(anyString(), any());
+    verify(requestBuilder).get();
   }
 
   @Test
   void queryNftsByTokenIdHitsExpectedPath() throws HieroException {
-    respondWith(EMPTY_NFTS_RESPONSE);
-
-    final MirrorNodeClientImpl client = newClient();
-    final Page<Nft> page = client.queryNftsByTokenId(TokenId.fromString("0.0.2002"));
+    final Page<Nft> page = newClient().queryNftsByTokenId(TOKEN_ID);
 
     assertNotNull(page);
     assertEquals(0, page.getSize());
-    assertEquals(TOKEN_NFTS_PATH, lastRequestedPath.get());
+    verify(webTarget).path(TOKEN_NFTS_PATH);
+    verify(webTarget, never()).queryParam(anyString(), any());
   }
 
   @Test
   void queryNftsByAccountAndTokenIdIncludesAccountFilter() throws HieroException {
-    respondWith(EMPTY_NFTS_RESPONSE);
-
-    final MirrorNodeClientImpl client = newClient();
-    final Page<Nft> page =
-        client.queryNftsByAccountAndTokenId(
-            AccountId.fromString("0.0.1001"), TokenId.fromString("0.0.2002"));
+    final Page<Nft> page = newClient().queryNftsByAccountAndTokenId(ACCOUNT_ID, TOKEN_ID);
 
     assertNotNull(page);
     assertEquals(0, page.getSize());
-    assertEquals(TOKEN_NFTS_FOR_ACCOUNT_PATH, lastRequestedPath.get());
+    verify(webTarget).path(TOKEN_NFTS_PATH);
+    verify(webTarget).queryParam("account.id", "0.0.1001");
   }
 
   @Test
   void queryNftsByAccountParsesResponse() throws HieroException {
-    final String body =
-        "{\"nfts\":[{"
-            + "\"account_id\":\"0.0.1001\","
-            + "\"created_timestamp\":\"1700000000.000000000\","
-            + "\"modified_timestamp\":\"1700000001.000000000\","
-            + "\"deleted\":false,"
-            + "\"metadata\":\""
-            + NFT_METADATA_BASE64
-            + "\","
-            + "\"serial_number\":1,"
-            + "\"token_id\":\"0.0.2002\""
-            + "}],\"links\":{\"next\":null}}";
-    respondWith(body);
+    when(response.readEntity(JsonObject.class)).thenReturn(singleNftResponse());
 
-    final MirrorNodeClientImpl client = newClient();
-    final Page<Nft> page = client.queryNftsByAccount(AccountId.fromString("0.0.1001"));
+    final Page<Nft> page = newClient().queryNftsByAccount(ACCOUNT_ID);
 
     assertEquals(1, page.getSize());
     final List<Nft> data = page.getData();
-    assertEquals(TokenId.fromString("0.0.2002"), data.get(0).tokenId());
+    assertEquals(TOKEN_ID, data.get(0).tokenId());
+    assertEquals(ACCOUNT_ID, data.get(0).owner());
     assertEquals(1L, data.get(0).serial());
     assertArrayEquals(NFT_METADATA.getBytes(StandardCharsets.UTF_8), data.get(0).metadata());
   }
 
   @Test
   void queryNftsByAccountRejectsNullInput() {
-    respondWith(EMPTY_NFTS_RESPONSE);
-
-    final MirrorNodeClientImpl client = newClient();
-    assertThrows(NullPointerException.class, () -> client.queryNftsByAccount((AccountId) null));
+    assertThrows(
+        NullPointerException.class, () -> newClient().queryNftsByAccount((AccountId) null));
+    verify(client, never()).target(anyString());
   }
 
   @Test
   void queryNftsByTokenIdRejectsNullInput() {
-    respondWith(EMPTY_NFTS_RESPONSE);
-
-    final MirrorNodeClientImpl client = newClient();
-    assertThrows(NullPointerException.class, () -> client.queryNftsByTokenId((TokenId) null));
+    assertThrows(NullPointerException.class, () -> newClient().queryNftsByTokenId((TokenId) null));
+    verify(client, never()).target(anyString());
   }
 
   private MirrorNodeClientImpl newClient() {
-    return new MirrorNodeClientImpl(
-        new MirrorNodeRestClientImpl(baseUrl), new MirrorNodeJsonConverterImpl());
+    return new MirrorNodeClientImpl(restClient, new MirrorNodeJsonConverterImpl());
   }
 
-  private void respondWith(final String body) {
-    final HttpHandler handler =
-        new HttpHandler() {
-          @Override
-          public void handle(final HttpExchange exchange) throws IOException {
-            final String path = exchange.getRequestURI().getRawPath();
-            final String query = exchange.getRequestURI().getRawQuery();
-            lastRequestedPath.set(query == null ? path : path + "?" + query);
-            final byte[] payload = body.getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set(CONTENT_TYPE_HEADER, APPLICATION_JSON);
-            exchange.sendResponseHeaders(200, payload.length);
-            exchange.getResponseBody().write(payload);
-            exchange.close();
-          }
-        };
-    server.createContext("/", handler);
+  private static JsonObject emptyNftsResponse() {
+    return Json.createObjectBuilder()
+        .add("nfts", Json.createArrayBuilder().build())
+        .add("links", Json.createObjectBuilder().add("next", JsonObject.NULL).build())
+        .build();
+  }
+
+  private static JsonObject singleNftResponse() {
+    final JsonArray nfts =
+        Json.createArrayBuilder()
+            .add(
+                Json.createObjectBuilder()
+                    .add("account_id", "0.0.1001")
+                    .add("created_timestamp", "1700000000.000000000")
+                    .add("modified_timestamp", "1700000001.000000000")
+                    .add("deleted", false)
+                    .add("metadata", NFT_METADATA_BASE64)
+                    .add("serial_number", 1)
+                    .add("token_id", "0.0.2002")
+                    .build())
+            .build();
+    return Json.createObjectBuilder()
+        .add("nfts", nfts)
+        .add("links", Json.createObjectBuilder().add("next", JsonObject.NULL).build())
+        .build();
   }
 }

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeJsonConverterImplNftTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeJsonConverterImplNftTest.java
@@ -1,0 +1,114 @@
+package org.hiero.microprofile.test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.TokenId;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.hiero.base.data.Nft;
+import org.hiero.microprofile.implementation.MirrorNodeJsonConverterImpl;
+import org.junit.jupiter.api.Test;
+
+class MirrorNodeJsonConverterImplNftTest {
+
+  private static final String TOKEN_ID = "0.0.2002";
+  private static final String ACCOUNT_ID = "0.0.1001";
+  private static final String NFT_METADATA = "test NFT";
+  private static final String NFT_METADATA_BASE64 = "dGVzdCBORlQ=";
+
+  private final MirrorNodeJsonConverterImpl converter = new MirrorNodeJsonConverterImpl();
+
+  @Test
+  void toNftsReturnsEmptyWhenKeyMissing() {
+    final JsonObject jsonObject = parse("{\"links\":{\"next\":null}}");
+
+    final List<Nft> result = converter.toNfts(jsonObject);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void toNftsReturnsEmptyForEmptyArray() {
+    final JsonObject jsonObject = parse("{\"nfts\":[],\"links\":{\"next\":null}}");
+
+    final List<Nft> result = converter.toNfts(jsonObject);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void toNftsParsesSingleEntry() {
+    final String json =
+        "{\"nfts\":[{"
+            + "\"account_id\":\""
+            + ACCOUNT_ID
+            + "\","
+            + "\"created_timestamp\":\"1700000000.000000000\","
+            + "\"modified_timestamp\":\"1700000001.000000000\","
+            + "\"deleted\":false,"
+            + "\"metadata\":\""
+            + NFT_METADATA_BASE64
+            + "\","
+            + "\"serial_number\":1,"
+            + "\"token_id\":\""
+            + TOKEN_ID
+            + "\""
+            + "}],\"links\":{\"next\":null}}";
+    final JsonObject jsonObject = parse(json);
+
+    final List<Nft> result = converter.toNfts(jsonObject);
+
+    assertEquals(1, result.size());
+    final Nft nft = result.get(0);
+    assertEquals(TokenId.fromString(TOKEN_ID), nft.tokenId());
+    assertEquals(AccountId.fromString(ACCOUNT_ID), nft.owner());
+    assertEquals(1L, nft.serial());
+    assertArrayEquals(NFT_METADATA.getBytes(StandardCharsets.UTF_8), nft.metadata());
+  }
+
+  @Test
+  void toNftsParsesMultipleEntries() {
+    final String json =
+        "{\"nfts\":[{"
+            + "\"account_id\":\""
+            + ACCOUNT_ID
+            + "\","
+            + "\"created_timestamp\":\"1700000000.000000000\","
+            + "\"modified_timestamp\":\"1700000001.000000000\","
+            + "\"deleted\":false,"
+            + "\"metadata\":\"\","
+            + "\"serial_number\":1,"
+            + "\"token_id\":\""
+            + TOKEN_ID
+            + "\"},{"
+            + "\"account_id\":\""
+            + ACCOUNT_ID
+            + "\","
+            + "\"created_timestamp\":\"1700000000.000000000\","
+            + "\"modified_timestamp\":\"1700000002.000000000\","
+            + "\"deleted\":false,"
+            + "\"metadata\":\"\","
+            + "\"serial_number\":2,"
+            + "\"token_id\":\""
+            + TOKEN_ID
+            + "\""
+            + "}],\"links\":{\"next\":null}}";
+    final JsonObject jsonObject = parse(json);
+
+    final List<Nft> result = converter.toNfts(jsonObject);
+
+    assertEquals(2, result.size());
+    assertEquals(1L, result.get(0).serial());
+    assertEquals(2L, result.get(1).serial());
+  }
+
+  private static JsonObject parse(final String json) {
+    return Json.createReader(new StringReader(json)).readObject();
+  }
+}

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/NftRepositoryTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/NftRepositoryTest.java
@@ -1,0 +1,91 @@
+package org.hiero.microprofile.test;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.TokenId;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.Configuration;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import jakarta.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.hiero.base.AccountClient;
+import org.hiero.base.HieroContext;
+import org.hiero.base.NftClient;
+import org.hiero.base.data.Account;
+import org.hiero.base.data.Nft;
+import org.hiero.base.data.Page;
+import org.hiero.base.mirrornode.NftRepository;
+import org.hiero.microprofile.ClientProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@HelidonTest
+@AddBean(ClientProvider.class)
+@Configuration(useExisting = true)
+public class NftRepositoryTest {
+
+  @BeforeAll
+  static void setup() {
+    final Config build =
+        ConfigProviderResolver.instance().getBuilder().withSources(new TestConfigSource()).build();
+    ConfigProviderResolver.instance()
+        .registerConfig(build, Thread.currentThread().getContextClassLoader());
+  }
+
+  @Inject private NftClient nftClient;
+
+  @Inject private AccountClient accountClient;
+
+  @Inject private NftRepository nftRepository;
+
+  @Inject private HieroContext hieroContext;
+
+  @Test
+  void findMintedNftsByTypeOwnerAndOwnerAndType() throws Exception {
+    final String name = "Tokemon cards";
+    final String symbol = "TOK";
+    final byte[] metadata1 = "https://example.com/metadata1".getBytes(StandardCharsets.UTF_8);
+    final byte[] metadata2 = "https://example.com/metadata2".getBytes(StandardCharsets.UTF_8);
+    final TokenId tokenId = nftClient.createNftType(name, symbol);
+    final List<Long> serials = nftClient.mintNfts(tokenId, metadata1, metadata2);
+    final Account account = accountClient.createAccount();
+    final AccountId newOwner = account.accountId();
+
+    nftClient.associateNft(tokenId, account);
+    nftClient.transferNft(tokenId, serials.get(0), hieroContext.getOperatorAccount(), newOwner);
+    nftClient.transferNft(tokenId, serials.get(1), hieroContext.getOperatorAccount(), newOwner);
+    Thread.sleep(10_000);
+
+    final Page<Nft> nftsByType = nftRepository.findByType(tokenId);
+    final Page<Nft> nftsByOwner = nftRepository.findByOwner(newOwner);
+    final Page<Nft> nftsByOwnerAndType = nftRepository.findByOwnerAndType(newOwner, tokenId);
+
+    assertContainsNft(nftsByType.getData(), tokenId, serials.get(0), newOwner, metadata1);
+    assertContainsNft(nftsByType.getData(), tokenId, serials.get(1), newOwner, metadata2);
+    assertContainsNft(nftsByOwner.getData(), tokenId, serials.get(0), newOwner, metadata1);
+    assertContainsNft(nftsByOwner.getData(), tokenId, serials.get(1), newOwner, metadata2);
+    assertContainsNft(nftsByOwnerAndType.getData(), tokenId, serials.get(0), newOwner, metadata1);
+    assertContainsNft(nftsByOwnerAndType.getData(), tokenId, serials.get(1), newOwner, metadata2);
+  }
+
+  private static void assertContainsNft(
+      final List<Nft> nfts,
+      final TokenId tokenId,
+      final long serial,
+      final AccountId owner,
+      final byte[] metadata) {
+    Assertions.assertTrue(
+        nfts.stream()
+            .anyMatch(
+                nft ->
+                    tokenId.equals(nft.tokenId())
+                        && serial == nft.serial()
+                        && owner.equals(nft.owner())
+                        && Arrays.equals(metadata, nft.metadata())),
+        "Expected NFT " + tokenId + "/" + serial + " for owner " + owner);
+  }
+}

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/NftRepositoryTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/NftRepositoryTest.java
@@ -45,7 +45,67 @@ public class NftRepositoryTest {
   @Inject private HieroContext hieroContext;
 
   @Test
-  void findMintedNftsByTypeOwnerAndOwnerAndType() throws Exception {
+  void findMintedNftsByType() throws Exception {
+    final NftFixture fixture = createMintedNftFixture();
+
+    final Page<Nft> nftsByType = nftRepository.findByType(fixture.tokenId());
+
+    assertContainsNft(
+        nftsByType.getData(),
+        fixture.tokenId(),
+        fixture.serials().get(0),
+        fixture.owner(),
+        fixture.metadata1());
+    assertContainsNft(
+        nftsByType.getData(),
+        fixture.tokenId(),
+        fixture.serials().get(1),
+        fixture.owner(),
+        fixture.metadata2());
+  }
+
+  @Test
+  void findMintedNftsByOwner() throws Exception {
+    final NftFixture fixture = createMintedNftFixture();
+
+    final Page<Nft> nftsByOwner = nftRepository.findByOwner(fixture.owner());
+
+    assertContainsNft(
+        nftsByOwner.getData(),
+        fixture.tokenId(),
+        fixture.serials().get(0),
+        fixture.owner(),
+        fixture.metadata1());
+    assertContainsNft(
+        nftsByOwner.getData(),
+        fixture.tokenId(),
+        fixture.serials().get(1),
+        fixture.owner(),
+        fixture.metadata2());
+  }
+
+  @Test
+  void findMintedNftsByOwnerAndType() throws Exception {
+    final NftFixture fixture = createMintedNftFixture();
+
+    final Page<Nft> nftsByOwnerAndType =
+        nftRepository.findByOwnerAndType(fixture.owner(), fixture.tokenId());
+
+    assertContainsNft(
+        nftsByOwnerAndType.getData(),
+        fixture.tokenId(),
+        fixture.serials().get(0),
+        fixture.owner(),
+        fixture.metadata1());
+    assertContainsNft(
+        nftsByOwnerAndType.getData(),
+        fixture.tokenId(),
+        fixture.serials().get(1),
+        fixture.owner(),
+        fixture.metadata2());
+  }
+
+  private NftFixture createMintedNftFixture() throws Exception {
     final String name = "Tokemon cards";
     final String symbol = "TOK";
     final byte[] metadata1 = "https://example.com/metadata1".getBytes(StandardCharsets.UTF_8);
@@ -60,17 +120,11 @@ public class NftRepositoryTest {
     nftClient.transferNft(tokenId, serials.get(1), hieroContext.getOperatorAccount(), newOwner);
     Thread.sleep(10_000);
 
-    final Page<Nft> nftsByType = nftRepository.findByType(tokenId);
-    final Page<Nft> nftsByOwner = nftRepository.findByOwner(newOwner);
-    final Page<Nft> nftsByOwnerAndType = nftRepository.findByOwnerAndType(newOwner, tokenId);
-
-    assertContainsNft(nftsByType.getData(), tokenId, serials.get(0), newOwner, metadata1);
-    assertContainsNft(nftsByType.getData(), tokenId, serials.get(1), newOwner, metadata2);
-    assertContainsNft(nftsByOwner.getData(), tokenId, serials.get(0), newOwner, metadata1);
-    assertContainsNft(nftsByOwner.getData(), tokenId, serials.get(1), newOwner, metadata2);
-    assertContainsNft(nftsByOwnerAndType.getData(), tokenId, serials.get(0), newOwner, metadata1);
-    assertContainsNft(nftsByOwnerAndType.getData(), tokenId, serials.get(1), newOwner, metadata2);
+    return new NftFixture(tokenId, serials, newOwner, metadata1, metadata2);
   }
+
+  private record NftFixture(
+      TokenId tokenId, List<Long> serials, AccountId owner, byte[] metadata1, byte[] metadata2) {}
 
   private static void assertContainsNft(
       final List<Nft> nfts,


### PR DESCRIPTION
## Summary


Closes #172

`MirrorNodeClientImpl#queryNftsByAccount`, `queryNftsByAccountAndTokenId`, and `queryNftsByTokenId` throw `RuntimeException("Not implemented")`, leaving the MicroProfile client behind the Spring one. `MirrorNodeJsonConverterImpl#toNfts` also reads the wrong key (`transactions` instead of `nfts`) and throws on an empty `nfts` array.

## Changes

- Implement the three NFT query methods against the Mirror Node REST API:
  - `GET /api/v1/accounts/{accountId}/nfts`
  - `GET /api/v1/tokens/{tokenId}/nfts`
  - `GET /api/v1/tokens/{tokenId}/nfts?account.id={accountId}`
- Fix `toNfts` to read `nfts`, tolerate empty arrays, and decode base64 NFT metadata.
- Add `MirrorNodeClientImplNftTest`, `MirrorNodeJsonConverterImplNftTest`, and a MicroProfile `NftRepositoryTest` e2e case covering `findByType`, `findByOwner`, and `findByOwnerAndType`.

## Test plan

- [x] `mvn -pl hiero-enterprise-microprofile -am spotless:apply test -Dtest=MirrorNodeClientImplNftTest,MirrorNodeJsonConverterImplNftTest -Dsurefire.failIfNoSpecifiedTests=false` (10/10 pass)
- [x] `mvn -pl hiero-enterprise-microprofile -am spotless:apply test -Dtest=NftRepositoryTest -Dsurefire.failIfNoSpecifiedTests=false` (live testnet, 1/1 pass)
- [ ] CI green
