### PR TITLE
fix: reuse MicroProfile mirror-node REST client

### DIFF
--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
@@ -1,6 +1,7 @@
 package org.hiero.microprofile;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperties;
@@ -142,14 +143,30 @@ public class ClientProvider {
   @NonNull
   @Produces
   @ApplicationScoped
-  MirrorNodeClient createMirrorNodeClient(@NonNull final HieroConfig hieroConfig) {
+  MirrorNodeRestClientImpl createMirrorNodeRestClient(@NonNull final HieroConfig hieroConfig) {
     final String target =
         hieroConfig.getMirrorNodeAddresses().stream()
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("No mirror node addresses configured"));
-    final MirrorNodeRestClientImpl restClient = new MirrorNodeRestClientImpl(target);
-    final MirrorNodeJsonConverterImpl jsonConverter = new MirrorNodeJsonConverterImpl();
-    return new MirrorNodeClientImpl(restClient, jsonConverter);
+    return new MirrorNodeRestClientImpl(target);
+  }
+
+  void disposeMirrorNodeRestClient(@Disposes @NonNull final MirrorNodeRestClientImpl restClient) {
+    restClient.close();
+  }
+
+  @NonNull
+  @Produces
+  @ApplicationScoped
+  MirrorNodeClient createMirrorNodeClient(@NonNull final MirrorNodeRestClientImpl restClient) {
+    return new MirrorNodeClientImpl(restClient, new MirrorNodeJsonConverterImpl());
+  }
+
+  @NonNull
+  @Produces
+  @ApplicationScoped
+  BlockRepository createBlockRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
+    return new BlockRepositoryImpl(mirrorNodeClient);
   }
 
   @NonNull

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -69,7 +69,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/tokens?account.id=" + accountId;
     final Function<JsonObject, List<TransactionInfo>> dataExtractionFunction =
         node -> jsonConverter.toTransactionInfos(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(
+        restClient.getClient(), restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
@@ -80,7 +81,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/tokens?account.id=" + accountId + "&transactiontype=" + type;
     final Function<JsonObject, List<TransactionInfo>> dataExtractionFunction =
         node -> jsonConverter.toTransactionInfos(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(
+        restClient.getClient(), restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
@@ -91,7 +93,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/tokens?account.id=" + accountId + "&result=" + result;
     final Function<JsonObject, List<TransactionInfo>> dataExtractionFunction =
         node -> jsonConverter.toTransactionInfos(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(
+        restClient.getClient(), restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
@@ -102,7 +105,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/tokens?account.id=" + accountId + "&type=" + type;
     final Function<JsonObject, List<TransactionInfo>> dataExtractionFunction =
         node -> jsonConverter.toTransactionInfos(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(
+        restClient.getClient(), restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
@@ -111,7 +115,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/tokens?account.id=" + accountId;
     final Function<JsonObject, List<Token>> dataExtractionFunction =
         node -> jsonConverter.toTokens(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(
+        restClient.getClient(), restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
@@ -120,7 +125,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/tokens/" + tokenId + "/balances";
     final Function<JsonObject, List<Balance>> dataExtractionFunction =
         node -> jsonConverter.toBalances(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(
+        restClient.getClient(), restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
@@ -131,7 +137,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/tokens/" + tokenId + "/balances?account.id=" + accountId;
     final Function<JsonObject, List<Balance>> dataExtractionFunction =
         node -> jsonConverter.toBalances(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(
+        restClient.getClient(), restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
@@ -140,7 +147,8 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/topics/" + topicId + "/messages";
     final Function<JsonObject, List<TopicMessage>> dataExtractionFunction =
         node -> jsonConverter.toTopicMessages(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(
+        restClient.getClient(), restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
@@ -158,6 +166,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/blocks";
     final Function<JsonObject, List<Block>> dataExtractionFunction =
         node -> jsonConverter.toBlocks(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(
+        restClient.getClient(), restClient.getTarget(), dataExtractionFunction, path);
   }
 }

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeRestClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeRestClientImpl.java
@@ -1,39 +1,65 @@
 package org.hiero.microprofile.implementation;
 
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.Objects;
 import org.hiero.base.HieroException;
 import org.hiero.base.implementation.MirrorNodeRestClient;
 import org.jspecify.annotations.NonNull;
 
-public class MirrorNodeRestClientImpl implements MirrorNodeRestClient<JsonObject> {
+public class MirrorNodeRestClientImpl implements MirrorNodeRestClient<JsonObject>, AutoCloseable {
+
+  private final Client client;
 
   private final String target;
 
-  public MirrorNodeRestClientImpl(String target) {
+  public MirrorNodeRestClientImpl(@NonNull final String target) {
+    Objects.requireNonNull(target, "target must not be null");
+    this.client = ClientBuilder.newClient();
     this.target = target;
   }
 
   @Override
-  public @NonNull JsonObject doGetCall(@NonNull String path) throws HieroException {
-    Client client = ClientBuilder.newClient();
-    Response response = client.target(target).path(path).request(MediaType.APPLICATION_JSON).get();
-
-    if (response.getStatus() == 404 || response.getStatus() == 400 || !response.hasEntity()) {
-      return JsonObject.EMPTY_JSON_OBJECT;
+  public @NonNull JsonObject doGetCall(@NonNull final String path) throws HieroException {
+    Objects.requireNonNull(path, "path must not be null");
+    try (final Response response =
+        client.target(target).path(path).request(MediaType.APPLICATION_JSON).get()) {
+      final int status = response.getStatus();
+      if (status == 404) {
+        return JsonObject.EMPTY_JSON_OBJECT;
+      }
+      if (status >= 400) {
+        throw new HieroException(
+            "Mirror node returned error " + status + " for path '" + path + "'");
+      }
+      if (!response.hasEntity()) {
+        return JsonObject.EMPTY_JSON_OBJECT;
+      }
+      return response.readEntity(JsonObject.class);
+    } catch (final ProcessingException e) {
+      throw new HieroException("Error calling mirror node for path '" + path + "'", e);
     }
-
-    if (response.getStatus() >= 400) {
-      throw new HieroException("Mirror Node call failed with status " + response.getStatus());
-    }
-
-    return response.readEntity(JsonObject.class);
   }
 
   public String getTarget() {
     return target;
+  }
+
+  /**
+   * Returns the shared JAX-RS client so pagination can reuse the same connection pool instead of
+   * allocating a new client per page.
+   */
+  @NonNull
+  public Client getClient() {
+    return client;
+  }
+
+  @Override
+  public void close() {
+    client.close();
   }
 }

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/RestBasedPage.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/RestBasedPage.java
@@ -1,8 +1,8 @@
 package org.hiero.microprofile.implementation;
 
 import jakarta.json.JsonObject;
+import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -14,6 +14,7 @@ import org.hiero.base.data.Page;
 import org.jspecify.annotations.NonNull;
 
 public class RestBasedPage<T> implements Page<T> {
+  private final Client client;
   private final String restTarget;
   private final Function<JsonObject, List<T>> dataExtractionFunction;
   private final List<T> data;
@@ -23,18 +24,21 @@ public class RestBasedPage<T> implements Page<T> {
   private final int number;
 
   public RestBasedPage(
+      @NonNull Client client,
       @NonNull String restTarget,
       @NonNull Function<JsonObject, @NonNull List<T>> dataExtractionFunction,
       @NonNull String path) {
-    this(restTarget, dataExtractionFunction, path, path, 0);
+    this(client, restTarget, dataExtractionFunction, path, path, 0);
   }
 
   public RestBasedPage(
+      @NonNull Client client,
       @NonNull String restTarget,
       @NonNull Function<JsonObject, List<T>> dataExtractionFunction,
       @NonNull String path,
       @NonNull String rootPath,
       int number) {
+    this.client = Objects.requireNonNull(client, "client must not be null");
     this.restTarget = Objects.requireNonNull(restTarget, "restTarget must not be null");
     this.dataExtractionFunction =
         Objects.requireNonNull(dataExtractionFunction, "dataExtractionFunction must not be null");
@@ -42,30 +46,39 @@ public class RestBasedPage<T> implements Page<T> {
     this.currentPath = Objects.requireNonNull(path, "path must not be null");
     this.number = number;
 
-    String[] pathParts = currentPath.split("\\?");
-    final String requestPath = pathParts[0];
-
-    try {
-      Client client = ClientBuilder.newClient();
-      WebTarget target = client.target(restTarget).path(requestPath);
-      if (pathParts.length > 1) {
-        String[] params = pathParts[1].split("&");
-        for (String param : params) {
-          String[] p = param.split("=");
-          target = target.queryParam(p[0], p[1]);
+    final String[] pathParts = currentPath.split("\\?", 2);
+    WebTarget target = client.target(restTarget).path(pathParts[0]);
+    if (pathParts.length == 2 && !pathParts[1].isEmpty()) {
+      for (final String param : pathParts[1].split("&")) {
+        if (param.isEmpty()) {
+          continue;
         }
+        final String[] kv = param.split("=", 2);
+        target = target.queryParam(kv[0], kv.length == 2 ? kv[1] : "");
       }
-      Response response = target.request(MediaType.APPLICATION_JSON).get();
+    }
 
-      final JsonObject jsonObject = response.readEntity(JsonObject.class);
+    try (final Response response = target.request(MediaType.APPLICATION_JSON).get()) {
+      final int status = response.getStatus();
+      if (status >= 400 && status != 404) {
+        throw new IllegalStateException(
+            "Mirror node returned error " + status + " for path '" + currentPath + "'");
+      }
+      final JsonObject jsonObject;
+      if (status == 404 || !response.hasEntity()) {
+        jsonObject = JsonObject.EMPTY_JSON_OBJECT;
+      } else {
+        jsonObject = response.readEntity(JsonObject.class);
+      }
       this.data = Collections.unmodifiableList(dataExtractionFunction.apply(jsonObject));
       this.nextPath = getNextPath(jsonObject);
-    } catch (Exception e) {
-      throw new IllegalStateException("Can not parse JSON: " + e);
+    } catch (final ProcessingException e) {
+      throw new IllegalStateException(
+          "Error calling mirror node for path '" + currentPath + "'", e);
     }
   }
 
-  private String getNextPath(final JsonObject jsonObject) {
+  private static String getNextPath(final JsonObject jsonObject) {
     if (!jsonObject.containsKey("links")) {
       return null;
     }
@@ -112,12 +125,13 @@ public class RestBasedPage<T> implements Page<T> {
     if (nextPath == null) {
       throw new IllegalStateException("No next Page");
     }
-    return new RestBasedPage<T>(restTarget, dataExtractionFunction, nextPath, rootPath, number + 1);
+    return new RestBasedPage<T>(
+        client, restTarget, dataExtractionFunction, nextPath, rootPath, number + 1);
   }
 
   @Override
   public Page<T> first() {
-    return new RestBasedPage<T>(restTarget, dataExtractionFunction, rootPath);
+    return new RestBasedPage<T>(client, restTarget, dataExtractionFunction, rootPath);
   }
 
   @Override

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeRestClientImplTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeRestClientImplTest.java
@@ -1,0 +1,146 @@
+package org.hiero.microprofile.test;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jakarta.json.JsonObject;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.hiero.base.HieroException;
+import org.hiero.microprofile.implementation.MirrorNodeRestClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link MirrorNodeRestClientImpl} reuses a single JAX-RS client across calls, closes
+ * response resources, and translates HTTP status codes into the documented contract (404 -> empty
+ * JSON, other 4xx/5xx -> {@link HieroException}).
+ */
+class MirrorNodeRestClientImplTest {
+
+  private HttpServer server;
+  private String baseUrl;
+
+  @BeforeEach
+  void startServer() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.start();
+    baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  private void registerHandler(final String path, final HttpHandler handler) {
+    server.createContext(path, handler);
+  }
+
+  private static HttpHandler staticResponse(final int status, final String body) {
+    return exchange -> {
+      final byte[] payload = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+      exchange.getResponseHeaders().set("Content-Type", "application/json");
+      exchange.sendResponseHeaders(status, payload.length == 0 ? -1 : payload.length);
+      if (payload.length > 0) {
+        exchange.getResponseBody().write(payload);
+      }
+      exchange.close();
+    };
+  }
+
+  @Test
+  void returnsParsedJsonForSuccessfulResponse() throws HieroException {
+    registerHandler("/api/v1/accounts/0.0.42", staticResponse(200, "{\"account\":\"0.0.42\"}"));
+    try (final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(baseUrl)) {
+      final JsonObject result = client.doGetCall("/api/v1/accounts/0.0.42");
+      Assertions.assertEquals("0.0.42", result.getString("account"));
+    }
+  }
+
+  @Test
+  void returnsEmptyJsonForNotFound() throws HieroException {
+    registerHandler("/api/v1/accounts/missing", staticResponse(404, "{\"_status\":\"not found\"}"));
+    try (final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(baseUrl)) {
+      final JsonObject result = client.doGetCall("/api/v1/accounts/missing");
+      Assertions.assertTrue(result.isEmpty());
+    }
+  }
+
+  @Test
+  void returnsEmptyJsonWhenSuccessfulResponseHasNoBody() throws HieroException {
+    registerHandler("/api/v1/network/empty", staticResponse(204, null));
+    try (final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(baseUrl)) {
+      final JsonObject result = client.doGetCall("/api/v1/network/empty");
+      Assertions.assertTrue(result.isEmpty());
+    }
+  }
+
+  @Test
+  void throwsHieroExceptionForClientError() {
+    registerHandler("/api/v1/bad", staticResponse(400, "{\"_status\":\"bad request\"}"));
+    try (final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(baseUrl)) {
+      final HieroException thrown =
+          Assertions.assertThrows(HieroException.class, () -> client.doGetCall("/api/v1/bad"));
+      Assertions.assertTrue(thrown.getMessage().contains("400"));
+      Assertions.assertTrue(thrown.getMessage().contains("/api/v1/bad"));
+    }
+  }
+
+  @Test
+  void throwsHieroExceptionForServerError() {
+    registerHandler("/api/v1/oops", staticResponse(500, "{\"_status\":\"server error\"}"));
+    try (final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(baseUrl)) {
+      final HieroException thrown =
+          Assertions.assertThrows(HieroException.class, () -> client.doGetCall("/api/v1/oops"));
+      Assertions.assertTrue(thrown.getMessage().contains("500"));
+      Assertions.assertTrue(thrown.getMessage().contains("/api/v1/oops"));
+    }
+  }
+
+  @Test
+  void throwsHieroExceptionForServerErrorWithoutBody() {
+    registerHandler("/api/v1/no-body", staticResponse(500, null));
+    try (final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(baseUrl)) {
+      final HieroException thrown =
+          Assertions.assertThrows(HieroException.class, () -> client.doGetCall("/api/v1/no-body"));
+      Assertions.assertTrue(thrown.getMessage().contains("500"));
+      Assertions.assertTrue(thrown.getMessage().contains("/api/v1/no-body"));
+    }
+  }
+
+  @Test
+  void multipleCallsReuseTheSameClient() throws HieroException {
+    registerHandler("/api/v1/network/fees", staticResponse(200, "{\"fees\":[]}"));
+    try (final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(baseUrl)) {
+      for (int i = 0; i < 20; i++) {
+        final JsonObject result = client.doGetCall("/api/v1/network/fees");
+        Assertions.assertTrue(result.containsKey("fees"));
+      }
+    }
+  }
+
+  @Test
+  void closeIsIdempotent() {
+    final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(baseUrl);
+    Assertions.assertDoesNotThrow(client::close);
+    Assertions.assertDoesNotThrow(client::close);
+  }
+
+  @Test
+  void constructorRejectsNullTarget() {
+    Assertions.assertThrows(NullPointerException.class, () -> new MirrorNodeRestClientImpl(null));
+  }
+
+  @Test
+  void getClientAndGetTargetExposeSharedResources() {
+    try (final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(baseUrl)) {
+      Assertions.assertSame(client.getClient(), client.getClient());
+      Assertions.assertEquals(baseUrl, client.getTarget());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Reuse a single JAX-RS Client/WebTarget for MicroProfile mirror-node REST calls instead of creating a client per request/page.
- Close Response resources with try-with-resources and dispose the CDI-managed REST client on shutdown.
- Treat non-404 4xx/5xx mirror-node responses as errors, including empty-body failures.

## Test plan
- mvn -pl hiero-enterprise-microprofile spotless:check
- mvn -pl hiero-enterprise-microprofile test -Dtest=MirrorNodeRestClientImplTest -DskipITs
- mvn -pl hiero-enterprise-microprofile test -Dtest=TokenRepositoryTest#testNullParam+testQueryTokenByIdReturnEmptyOptionalForInvalidId -DskipITs

Closes #78