### PR TITLE
fix(base): correct transferFundsToAccount typo

### DIFF
--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ProtocolLayerClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ProtocolLayerClientImpl.java
@@ -354,12 +354,12 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
             .setMaxTransactionFee(request.maxTransactionFee())
             .setTransactionValidDuration(request.transactionValidDuration())
             .setAccountId(request.toDelete().accountId());
-    if (request.transferFoundsToAccount() != null) {
-      transaction.setTransferAccountId(request.transferFoundsToAccount().accountId());
+    if (request.transferFundsToAccount() != null) {
+      transaction.setTransferAccountId(request.transferFundsToAccount().accountId());
       sign(
           transaction,
           request.toDelete().privateKey(),
-          request.transferFoundsToAccount().privateKey());
+          request.transferFundsToAccount().privateKey());
     } else {
       transaction.setTransferAccountId(hieroContext.getOperatorAccount().accountId());
       sign(

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/protocol/data/AccountDeleteRequest.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/protocol/data/AccountDeleteRequest.java
@@ -11,7 +11,7 @@ public record AccountDeleteRequest(
     @NonNull Hbar maxTransactionFee,
     @NonNull Duration transactionValidDuration,
     @NonNull Account toDelete,
-    @Nullable Account transferFoundsToAccount)
+    @Nullable Account transferFundsToAccount)
     implements TransactionRequest {
 
   public AccountDeleteRequest {
@@ -24,9 +24,9 @@ public record AccountDeleteRequest(
     if (transactionValidDuration.isNegative() || transactionValidDuration.isZero()) {
       throw new IllegalArgumentException("transactionValidDuration must be positive");
     }
-    if (transferFoundsToAccount != null
-        && Objects.equals(toDelete.accountId(), transferFoundsToAccount.accountId())) {
-      throw new IllegalArgumentException("transferFoundsToAccount must be different from toDelete");
+    if (transferFundsToAccount != null
+        && Objects.equals(toDelete.accountId(), transferFundsToAccount.accountId())) {
+      throw new IllegalArgumentException("transferFundsToAccount must be different from toDelete");
     }
   }
 
@@ -37,11 +37,11 @@ public record AccountDeleteRequest(
 
   @NonNull
   public static AccountDeleteRequest of(
-      @NonNull Account toDelete, @Nullable Account transferFoundsToAccount) {
+      @NonNull Account toDelete, @Nullable Account transferFundsToAccount) {
     return new AccountDeleteRequest(
         DEFAULT_MAX_TRANSACTION_FEE,
         DEFAULT_TRANSACTION_VALID_DURATION,
         toDelete,
-        transferFoundsToAccount);
+        transferFundsToAccount);
   }
 }

--- a/hiero-enterprise-base/src/test/java/org/hiero/base/test/ProtocolLayerDataCreationTests.java
+++ b/hiero-enterprise-base/src/test/java/org/hiero/base/test/ProtocolLayerDataCreationTests.java
@@ -216,53 +216,53 @@ public class ProtocolLayerDataCreationTests {
     final Hbar maxTransactionFee = Hbar.fromTinybars(1000);
     final Duration transactionValidDuration = Duration.ofSeconds(10);
     final Account toDelete = Account.of(new AccountId(0, 0, 12345), PrivateKey.generateECDSA());
-    final Account transferFoundsToAccount =
+    final Account transferFundsToAccount =
         Account.of(new AccountId(0, 0, 54321), PrivateKey.generateECDSA());
 
     // then
     Assertions.assertDoesNotThrow(() -> AccountDeleteRequest.of(toDelete));
-    Assertions.assertDoesNotThrow(() -> AccountDeleteRequest.of(toDelete, transferFoundsToAccount));
+    Assertions.assertDoesNotThrow(() -> AccountDeleteRequest.of(toDelete, transferFundsToAccount));
     Assertions.assertDoesNotThrow(() -> AccountDeleteRequest.of(toDelete, null));
     Assertions.assertDoesNotThrow(
         () ->
             new AccountDeleteRequest(
-                maxTransactionFee, transactionValidDuration, toDelete, transferFoundsToAccount));
+                maxTransactionFee, transactionValidDuration, toDelete, transferFundsToAccount));
     Assertions.assertDoesNotThrow(
         () ->
             new AccountDeleteRequest(maxTransactionFee, transactionValidDuration, toDelete, null));
     Assertions.assertThrows(NullPointerException.class, () -> AccountDeleteRequest.of(null));
     Assertions.assertThrows(
-        NullPointerException.class, () -> AccountDeleteRequest.of(null, transferFoundsToAccount));
+        NullPointerException.class, () -> AccountDeleteRequest.of(null, transferFundsToAccount));
     Assertions.assertThrows(
         NullPointerException.class,
         () ->
             new AccountDeleteRequest(
-                null, transactionValidDuration, toDelete, transferFoundsToAccount));
+                null, transactionValidDuration, toDelete, transferFundsToAccount));
     Assertions.assertThrows(
         NullPointerException.class,
-        () -> new AccountDeleteRequest(maxTransactionFee, null, toDelete, transferFoundsToAccount));
+        () -> new AccountDeleteRequest(maxTransactionFee, null, toDelete, transferFundsToAccount));
     Assertions.assertThrows(
         NullPointerException.class,
         () ->
             new AccountDeleteRequest(
-                maxTransactionFee, transactionValidDuration, null, transferFoundsToAccount));
+                maxTransactionFee, transactionValidDuration, null, transferFundsToAccount));
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> AccountDeleteRequest.of(toDelete, toDelete));
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () ->
             new AccountDeleteRequest(
-                Hbar.from(-1000), transactionValidDuration, toDelete, transferFoundsToAccount));
+                Hbar.from(-1000), transactionValidDuration, toDelete, transferFundsToAccount));
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () ->
             new AccountDeleteRequest(
-                maxTransactionFee, Duration.ZERO, toDelete, transferFoundsToAccount));
+                maxTransactionFee, Duration.ZERO, toDelete, transferFundsToAccount));
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () ->
             new AccountDeleteRequest(
-                maxTransactionFee, Duration.ofSeconds(-10), toDelete, transferFoundsToAccount));
+                maxTransactionFee, Duration.ofSeconds(-10), toDelete, transferFundsToAccount));
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () ->


### PR DESCRIPTION
## Summary
- rename `AccountDeleteRequest.transferFoundsToAccount` to `transferFundsToAccount`
- update account delete transaction handling to use the corrected accessor
- align protocol-layer data creation tests with the corrected name

## Testing
- `./mvnw -pl hiero-enterprise-base -am test -Dtest=ProtocolLayerDataCreationTests,AccountClientImplTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.repo.local=.m2/repository`

Note:
 The project seems early enough that these corrections shouldn’t break anything. 