### PR TITLE
fix(microprofile): return configured chainId and relayUrl in HieroConfigImpl

### DIFF
--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/HieroConfigImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/HieroConfigImpl.java
@@ -93,11 +93,11 @@ public class HieroConfigImpl implements HieroConfig {
 
   @Override
   public @NonNull Optional<Long> chainId() {
-    return Optional.empty();
+    return Optional.ofNullable(chainId);
   }
 
   @Override
   public @NonNull Optional<String> relayUrl() {
-    return Optional.empty();
+    return Optional.ofNullable(relayUrl);
   }
 }

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/HieroConfigImplTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/HieroConfigImplTest.java
@@ -1,0 +1,59 @@
+package org.hiero.microprofile.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.hashgraph.sdk.PrivateKey;
+import java.util.Optional;
+import java.util.Set;
+import org.hiero.base.config.ConsensusNode;
+import org.hiero.microprofile.HieroNetworkConfiguration;
+import org.hiero.microprofile.HieroOperatorConfiguration;
+import org.hiero.microprofile.implementation.HieroConfigImpl;
+import org.junit.jupiter.api.Test;
+
+class HieroConfigImplTest {
+
+  @Test
+  void shouldExposeChainIdAndRelayUrlFromKnownNetworkSettings() {
+    final HieroOperatorConfiguration operatorConfiguration =
+        new HieroOperatorConfiguration() {
+          @Override
+          public String getAccountId() {
+            return "0.0.1001";
+          }
+
+          @Override
+          public String getPrivateKey() {
+            return PrivateKey.generateED25519().toString();
+          }
+        };
+
+    final HieroNetworkConfiguration networkConfiguration =
+        new HieroNetworkConfiguration() {
+          @Override
+          public Optional<String> getName() {
+            return Optional.of("hedera-testnet");
+          }
+
+          @Override
+          public Optional<String> getMirrornode() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Optional<Long> getRequestTimeoutInMs() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Set<ConsensusNode> getNodes() {
+            return Set.of();
+          }
+        };
+
+    final HieroConfigImpl config = new HieroConfigImpl(operatorConfiguration, networkConfiguration);
+
+    assertEquals(Optional.of(296L), config.chainId());
+    assertEquals(Optional.of("https://testnet.hashio.io/api"), config.relayUrl());
+  }
+}

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/HieroConfigImplTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/HieroConfigImplTest.java
@@ -56,4 +56,48 @@ class HieroConfigImplTest {
     assertEquals(Optional.of(296L), config.chainId());
     assertEquals(Optional.of("https://testnet.hashio.io/api"), config.relayUrl());
   }
+
+  @Test
+  void shouldReturnEmptyChainIdAndRelayUrlForCustomNetwork() {
+    final HieroOperatorConfiguration operatorConfiguration =
+        new HieroOperatorConfiguration() {
+          @Override
+          public String getAccountId() {
+            return "0.0.1001";
+          }
+
+          @Override
+          public String getPrivateKey() {
+            return PrivateKey.generateED25519().toString();
+          }
+        };
+
+    final HieroNetworkConfiguration networkConfiguration =
+        new HieroNetworkConfiguration() {
+          @Override
+          public Optional<String> getName() {
+            return Optional.of("custom-network");
+          }
+
+          @Override
+          public Optional<String> getMirrornode() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Optional<Long> getRequestTimeoutInMs() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Set<ConsensusNode> getNodes() {
+            return Set.of();
+          }
+        };
+
+    final HieroConfigImpl config = new HieroConfigImpl(operatorConfiguration, networkConfiguration);
+
+    assertEquals(Optional.empty(), config.chainId());
+    assertEquals(Optional.empty(), config.relayUrl());
+  }
 }


### PR DESCRIPTION

## Description
Fix `HieroConfigImpl` in MicroProfile to return configured values for:
- `chainId()`
- `relayUrl()`

Also adds a focused regression test (`HieroConfigImplTest`) for `hedera-testnet`.

## Related issue(s)
Fixes #90

## Notes for reviewer
Validated locally:
```bash
./mvnw -q -pl hiero-enterprise-microprofile -Dtest=HieroConfigImplTest test
./mvnw -q -pl hiero-enterprise-microprofile spotless:check
```
## Checklist
- [x] Tested
- [ ] Docs update not needed
