### PR TITLE
fix(base): clean misleading validation messages and contract call naming

### DIFF
--- a/hiero-enterprise-base/src/main/java/org/hiero/base/AccountClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/AccountClient.java
@@ -89,7 +89,7 @@ public interface AccountClient {
    */
   @NonNull
   default Hbar getAccountBalance(@NonNull String accountId) throws HieroException {
-    Objects.requireNonNull(accountId, "newAccountId must not be null");
+    Objects.requireNonNull(accountId, "accountId must not be null");
     return getAccountBalance(AccountId.fromString(accountId));
   }
 

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/data/Account.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/data/Account.java
@@ -17,7 +17,7 @@ public record Account(
     @NonNull AccountId accountId, @NonNull PublicKey publicKey, @NonNull PrivateKey privateKey) {
 
   public Account {
-    Objects.requireNonNull(accountId, "newAccountId must not be null");
+    Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(publicKey, "publicKey must not be null");
     Objects.requireNonNull(privateKey, "privateKey must not be null");
   }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/FileClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/FileClientImpl.java
@@ -29,7 +29,7 @@ public class FileClientImpl implements FileClient {
 
   public FileClientImpl(@NonNull final ProtocolLayerClient protocolLayerClient) {
     this.protocolLayerClient =
-        Objects.requireNonNull(protocolLayerClient, "protocolLevelClient must not be null");
+        Objects.requireNonNull(protocolLayerClient, "protocolLayerClient must not be null");
   }
 
   @Override

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ProtocolLayerClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ProtocolLayerClientImpl.java
@@ -294,7 +294,7 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
   public ContractCallResult executeContractCallTransaction(
       @NonNull final ContractCallRequest request) throws HieroException {
     Objects.requireNonNull(request, "request must not be null");
-    final ContractFunctionParameters functionParams = createParameters(request.constructorParams());
+    final ContractFunctionParameters functionParams = createParameters(request.functionParams());
     final ContractExecuteTransaction transaction =
         new ContractExecuteTransaction()
             .setMaxTransactionFee(request.maxTransactionFee())

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/SmartContractClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/SmartContractClientImpl.java
@@ -32,7 +32,7 @@ public class SmartContractClientImpl implements SmartContractClient {
   public SmartContractClientImpl(
       @NonNull final ProtocolLayerClient protocolLayerClient, FileClient fileClient) {
     this.protocolLayerClient =
-        Objects.requireNonNull(protocolLayerClient, "protocolLevelClient must not be null");
+        Objects.requireNonNull(protocolLayerClient, "protocolLayerClient must not be null");
     this.fileClient = Objects.requireNonNull(fileClient, "fileClient must not be null");
   }
 

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/interceptors/ReceiveRecordInterceptor.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/interceptors/ReceiveRecordInterceptor.java
@@ -20,7 +20,7 @@ public interface ReceiveRecordInterceptor {
   /**
    * Intercept the call for receiving a record for a transaction.
    *
-   * @param handler the handler that will be used to receive the record
+   * @param handler the record handler to invoke
    * @return the record for the transaction
    * @throws Exception if the interceptor fails
    */
@@ -31,7 +31,7 @@ public interface ReceiveRecordInterceptor {
    *
    * @param transaction the transaction for which the record is received
    * @param receipt the receipt for the transaction
-   * @param function the function that will be used to receive the record
+   * @param function the callback that fetches the record from the receipt
    */
   record ReceiveRecordHandler(
       @NonNull Transaction transaction,
@@ -41,7 +41,7 @@ public interface ReceiveRecordInterceptor {
     public ReceiveRecordHandler {
       Objects.requireNonNull(transaction, "transaction must not be null");
       Objects.requireNonNull(receipt, "receipt must not be null");
-      Objects.requireNonNull(function, "handler must not be null");
+      Objects.requireNonNull(function, "function must not be null");
     }
 
     /**

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
@@ -142,7 +142,7 @@ public interface MirrorNodeClient {
   default Optional<Nft> queryNftsByAccountAndTokenIdAndSerial(
       @NonNull AccountId accountId, @NonNull TokenId tokenId, long serialNumber)
       throws HieroException {
-    Objects.requireNonNull(accountId, "newAccountId must not be null");
+    Objects.requireNonNull(accountId, "accountId must not be null");
     return queryNftsByTokenIdAndSerial(tokenId, serialNumber)
         .filter(nft -> Objects.equals(nft.owner(), accountId));
   }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
@@ -89,7 +89,7 @@ public interface TransactionRepository {
   default Page<TransactionInfo> findByAccountAndResult(
       @NonNull String accountId, @NonNull Result result) throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    Objects.requireNonNull(result, "type must not be null");
+    Objects.requireNonNull(result, "result must not be null");
     return findByAccountAndResult(AccountId.fromString(accountId), result);
   }
   ;

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/protocol/data/AccountBalanceRequest.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/protocol/data/AccountBalanceRequest.java
@@ -9,7 +9,7 @@ public record AccountBalanceRequest(
     @NonNull AccountId accountId, Hbar queryPayment, Hbar maxQueryPayment) implements QueryRequest {
 
   public AccountBalanceRequest {
-    Objects.requireNonNull(accountId, "newAccountId must not be null");
+    Objects.requireNonNull(accountId, "accountId must not be null");
   }
 
   @NonNull
@@ -19,7 +19,7 @@ public record AccountBalanceRequest(
 
   @NonNull
   public static AccountBalanceRequest of(@NonNull String accountId) {
-    Objects.requireNonNull(accountId, "newAccountId must not be null");
+    Objects.requireNonNull(accountId, "accountId must not be null");
     return of(AccountId.fromString(accountId));
   }
 

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/protocol/data/AccountCreateResult.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/protocol/data/AccountCreateResult.java
@@ -23,7 +23,7 @@ public record AccountCreateResult(
     Objects.requireNonNull(transactionHash, "transactionHash must not be null");
     Objects.requireNonNull(consensusTimestamp, "consensusTimestamp must not be null");
     Objects.requireNonNull(transactionFee, "transactionFee must not be null");
-    Objects.requireNonNull(newAccount, "newAccountId must not be null");
+    Objects.requireNonNull(newAccount, "newAccount must not be null");
     if (transactionFee.toTinybars() < 0) {
       throw new IllegalArgumentException("transactionFee must be non-negative");
     }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/protocol/data/ContractCallRequest.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/protocol/data/ContractCallRequest.java
@@ -14,7 +14,7 @@ public record ContractCallRequest(
     @NonNull Duration transactionValidDuration,
     @NonNull ContractId contractId,
     @NonNull String functionName,
-    @NonNull List<ContractParam<?>> constructorParams)
+    @NonNull List<ContractParam<?>> functionParams)
     implements TransactionRequest {
 
   public ContractCallRequest {
@@ -22,12 +22,12 @@ public record ContractCallRequest(
     Objects.requireNonNull(transactionValidDuration, "transactionValidDuration is required");
     Objects.requireNonNull(contractId, "contractId is required");
     Objects.requireNonNull(functionName, "functionName is required");
-    Objects.requireNonNull(constructorParams, "constructorParams is required");
+    Objects.requireNonNull(functionParams, "functionParams is required");
     if (maxTransactionFee.toTinybars() < 0) {
-      throw new IllegalArgumentException("maxTransactionFee must be at >= null");
+      throw new IllegalArgumentException("maxTransactionFee must be non-negative");
     }
     if (!transactionValidDuration.isPositive()) {
-      throw new IllegalArgumentException("transactionValidDuration must be at >= zero");
+      throw new IllegalArgumentException("transactionValidDuration must be positive");
     }
     if (functionName.isBlank() || functionName.contains(" ")) {
       throw new IllegalArgumentException("functionName must not be blank or contain spaces");
@@ -38,20 +38,20 @@ public record ContractCallRequest(
   public static ContractCallRequest of(
       @NonNull String contractId,
       @NonNull String functionName,
-      @Nullable ContractParam<?>... constructorParams) {
+      @Nullable ContractParam<?>... functionParams) {
     Objects.requireNonNull(contractId, "contractId must not be null");
-    return of(ContractId.fromString(contractId), functionName, constructorParams);
+    return of(ContractId.fromString(contractId), functionName, functionParams);
   }
 
   @NonNull
   public static ContractCallRequest of(
       @NonNull ContractId contractId,
       @NonNull String functionName,
-      @Nullable ContractParam<?>... constructorParams) {
-    if (constructorParams == null) {
+      @Nullable ContractParam<?>... functionParams) {
+    if (functionParams == null) {
       return of(contractId, functionName, List.of());
     } else {
-      return of(contractId, functionName, List.of(constructorParams));
+      return of(contractId, functionName, List.of(functionParams));
     }
   }
 
@@ -59,21 +59,21 @@ public record ContractCallRequest(
   public static ContractCallRequest of(
       @NonNull String contractId,
       @NonNull String functionName,
-      @NonNull List<ContractParam<?>> constructorParams) {
+      @NonNull List<ContractParam<?>> functionParams) {
     Objects.requireNonNull(contractId, "contractId must not be null");
-    return of(ContractId.fromString(contractId), functionName, constructorParams);
+    return of(ContractId.fromString(contractId), functionName, functionParams);
   }
 
   @NonNull
   public static ContractCallRequest of(
       @NonNull ContractId contractId,
       @NonNull String functionName,
-      @NonNull List<ContractParam<?>> constructorParams) {
+      @NonNull List<ContractParam<?>> functionParams) {
     return new ContractCallRequest(
         DEFAULT_MAX_TRANSACTION_FEE,
         DEFAULT_TRANSACTION_VALID_DURATION,
         contractId,
         functionName,
-        List.copyOf(constructorParams));
+        List.copyOf(functionParams));
   }
 }


### PR DESCRIPTION
## Summary

This PR cleans up misleading validation messages and confusing naming in the base module.

## Changes

- fixed incorrect null-check messages for `accountId` in:
  - `AccountClient`
  - `Account`
  - `AccountBalanceRequest`
  - `MirrorNodeClient`
- fixed incorrect null-check messages in:
  - `TransactionRepository` (`result` instead of `type`)
  - `AccountCreateResult` (`newAccount` instead of `newAccountId`)
  - `SmartContractClientImpl` (`protocolLayerClient` instead of `protocolLevelClient`)
  - `FileClientImpl` (`protocolLayerClient` instead of `protocolLevelClient`)
  - `ReceiveRecordInterceptor` (`function` instead of `handler`)
- clarified `ReceiveRecordInterceptor` docs so `handler` and `function` are described consistently
- renamed `ContractCallRequest` parameter naming from `constructorParams` to `functionParams`
- fixed invalid validation text in `ContractCallRequest`
  - `maxTransactionFee must be at >= null` -> `maxTransactionFee must be non-negative`
  - `transactionValidDuration must be at >= zero` -> `transactionValidDuration must be positive`
- updated `ProtocolLayerClientImpl` to use `request.functionParams()` for contract call execution

## Verification

Passed focused tests:
- `ProtocolLayerDataCreationTests`
- `AccountClientImplTest`