### PR TITLE
chore: add CI hardening to GitHub Action workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,6 +54,11 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v2.10.1
+      with:
+        egress-policy: audit
+
     - name: Checkout repository
       uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2.10.1
+        with:
+          egress-policy: audit
+
       - name: Checkout Repo
         uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,11 @@ jobs:
       # actions: read
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2.10.1
+        with:
+          egress-policy: audit
+
       - name: "Checkout code"
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1
         with:


### PR DESCRIPTION

**Description**:
This PR adds egress monitoring to our CI/CD pipelines using StepSecurity's `harden-runner`. This improves our security posture by auditing outbound network connections during build and analysis steps.

* Add `harden-runner` step to `codeql.yml`
* Add `harden-runner` step to `maven.yml`
* Add `harden-runner` step to `scorecard.yml`

**Related issue(s)**:

Fixes #94

**Notes for reviewer**:
The egress policy is set to `audit`, which means it will monitor and log all outbound traffic without blocking any existing connections. This ensures no breaking changes to the CI while providing the necessary security visibility.


