### PR TITLE
feat(mirror): ScheduleRepository and mirror schedule API

### DIFF
--- a/hiero-enterprise-base/src/main/java/org/hiero/base/data/Schedule.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/data/Schedule.java
@@ -1,0 +1,40 @@
+package org.hiero.base.data;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.ScheduleId;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/** Represents a scheduled transaction returned by the Mirror Node REST API. */
+public record Schedule(
+    @NonNull ScheduleId scheduleId,
+    @Nullable PublicKey adminKey,
+    boolean deleted,
+    @NonNull Instant consensusTimestamp,
+    @NonNull AccountId creatorAccountId,
+    @Nullable Instant executedTimestamp,
+    @Nullable Instant expirationTime,
+    @NonNull String memo,
+    @Nullable AccountId payerAccountId,
+    @NonNull List<ScheduleSignature> signatures,
+    byte @Nullable [] transactionBody,
+    boolean waitForExpiry) {
+
+  public Schedule {
+    Objects.requireNonNull(scheduleId, "scheduleId must not be null");
+    Objects.requireNonNull(consensusTimestamp, "consensusTimestamp must not be null");
+    Objects.requireNonNull(creatorAccountId, "creatorAccountId must not be null");
+    Objects.requireNonNull(memo, "memo must not be null");
+    signatures = List.copyOf(Objects.requireNonNull(signatures, "signatures must not be null"));
+    transactionBody = transactionBody == null ? null : transactionBody.clone();
+  }
+
+  @Override
+  public byte @Nullable [] transactionBody() {
+    return transactionBody == null ? null : transactionBody.clone();
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/data/ScheduleSignature.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/data/ScheduleSignature.java
@@ -1,0 +1,20 @@
+package org.hiero.base.data;
+
+import java.time.Instant;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+
+/** Represents a signature collected for a scheduled transaction. */
+public record ScheduleSignature(
+    @NonNull Instant consensusTimestamp,
+    @NonNull String publicKeyPrefix,
+    @NonNull String signature,
+    @NonNull String type) {
+
+  public ScheduleSignature {
+    Objects.requireNonNull(consensusTimestamp, "consensusTimestamp must not be null");
+    Objects.requireNonNull(publicKeyPrefix, "publicKeyPrefix must not be null");
+    Objects.requireNonNull(signature, "signature must not be null");
+    Objects.requireNonNull(type, "type must not be null");
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
@@ -2,6 +2,7 @@ package org.hiero.base.implementation;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
+import com.hedera.hashgraph.sdk.ScheduleId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
 import java.util.List;
@@ -18,6 +19,7 @@ import org.hiero.base.data.NetworkSupplies;
 import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftMetadata;
 import org.hiero.base.data.Page;
+import org.hiero.base.data.Schedule;
 import org.hiero.base.data.TokenInfo;
 import org.hiero.base.data.Topic;
 import org.hiero.base.data.TopicMessage;
@@ -104,6 +106,14 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
   @Override
   public @NonNull Optional<NftMetadata> getNftMetadata(TokenId tokenId) throws HieroException {
     throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public @NonNull Optional<Schedule> queryScheduleById(@NonNull final ScheduleId scheduleId)
+      throws HieroException {
+    Objects.requireNonNull(scheduleId, "scheduleId must not be null");
+    final JSON json = getRestClient().queryScheduleById(scheduleId);
+    return getJsonConverter().toSchedule(json);
   }
 
   @Override

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeJsonConverter.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeJsonConverter.java
@@ -12,6 +12,7 @@ import org.hiero.base.data.NetworkStake;
 import org.hiero.base.data.NetworkSupplies;
 import org.hiero.base.data.Nft;
 import org.hiero.base.data.Page;
+import org.hiero.base.data.Schedule;
 import org.hiero.base.data.Token;
 import org.hiero.base.data.TokenInfo;
 import org.hiero.base.data.Topic;
@@ -49,6 +50,12 @@ public interface MirrorNodeJsonConverter<JSON> {
   @NonNull Optional<TopicMessage> toTopicMessage(JSON json);
 
   @NonNull List<TopicMessage> toTopicMessages(JSON json);
+
+  @NonNull Optional<Schedule> toSchedule(@NonNull JSON json);
+
+  @NonNull Page<Schedule> toSchedulePage(@NonNull JSON json);
+
+  @NonNull List<Schedule> toSchedules(@NonNull JSON json);
 
   @NonNull Optional<Contract> toContract(@NonNull JSON json);
 

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
@@ -2,6 +2,7 @@ package org.hiero.base.implementation;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
+import com.hedera.hashgraph.sdk.ScheduleId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
 import java.util.Objects;
@@ -69,6 +70,12 @@ public interface MirrorNodeRestClient<JSON> {
   }
 
   @NonNull JSON doGetCall(@NonNull String path) throws HieroException;
+
+  @NonNull
+  default JSON queryScheduleById(@NonNull final ScheduleId scheduleId) throws HieroException {
+    Objects.requireNonNull(scheduleId, "scheduleId must not be null");
+    return doGetCall("/api/v1/schedules/" + scheduleId);
+  }
 
   @NonNull
   default JSON queryContracts() throws HieroException {

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
@@ -11,8 +11,6 @@ import org.jspecify.annotations.NonNull;
 
 public interface MirrorNodeRestClient<JSON> {
 
-  String SCHEDULES_PATH = "/api/v1/schedules";
-
   @NonNull
   default JSON queryNftsByTokenIdAndSerial(
       @NonNull final TokenId tokenId, @NonNull final long serialNumber) throws HieroException {
@@ -76,7 +74,7 @@ public interface MirrorNodeRestClient<JSON> {
   @NonNull
   default JSON queryScheduleById(@NonNull final ScheduleId scheduleId) throws HieroException {
     Objects.requireNonNull(scheduleId, "scheduleId must not be null");
-    return doGetCall(SCHEDULES_PATH + "/" + scheduleId);
+    return doGetCall("/api/v1/schedules/" + scheduleId);
   }
 
   @NonNull

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
@@ -11,6 +11,8 @@ import org.jspecify.annotations.NonNull;
 
 public interface MirrorNodeRestClient<JSON> {
 
+  String SCHEDULES_PATH = "/api/v1/schedules";
+
   @NonNull
   default JSON queryNftsByTokenIdAndSerial(
       @NonNull final TokenId tokenId, @NonNull final long serialNumber) throws HieroException {
@@ -74,7 +76,7 @@ public interface MirrorNodeRestClient<JSON> {
   @NonNull
   default JSON queryScheduleById(@NonNull final ScheduleId scheduleId) throws HieroException {
     Objects.requireNonNull(scheduleId, "scheduleId must not be null");
-    return doGetCall("/api/v1/schedules/" + scheduleId);
+    return doGetCall(SCHEDULES_PATH + "/" + scheduleId);
   }
 
   @NonNull

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ScheduleRepositoryImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ScheduleRepositoryImpl.java
@@ -1,0 +1,46 @@
+package org.hiero.base.implementation;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.ScheduleId;
+import java.util.Objects;
+import java.util.Optional;
+import org.hiero.base.HieroException;
+import org.hiero.base.data.Page;
+import org.hiero.base.data.Schedule;
+import org.hiero.base.mirrornode.MirrorNodeClient;
+import org.hiero.base.mirrornode.ScheduleRepository;
+import org.jspecify.annotations.NonNull;
+
+/** Implementation of ScheduleRepository that uses MirrorNodeClient to query schedule data. */
+public class ScheduleRepositoryImpl implements ScheduleRepository {
+
+  private final MirrorNodeClient mirrorNodeClient;
+
+  /**
+   * Creates a new ScheduleRepositoryImpl with the given MirrorNodeClient.
+   *
+   * @param mirrorNodeClient the mirror node client to use for queries
+   */
+  public ScheduleRepositoryImpl(@NonNull final MirrorNodeClient mirrorNodeClient) {
+    this.mirrorNodeClient =
+        Objects.requireNonNull(mirrorNodeClient, "mirrorNodeClient must not be null");
+  }
+
+  @NonNull
+  @Override
+  public Page<Schedule> findAll() throws HieroException {
+    return mirrorNodeClient.querySchedules();
+  }
+
+  @NonNull
+  @Override
+  public Optional<Schedule> findById(@NonNull final ScheduleId scheduleId) throws HieroException {
+    return mirrorNodeClient.queryScheduleById(scheduleId);
+  }
+
+  @NonNull
+  @Override
+  public Page<Schedule> findByAccountId(@NonNull final AccountId accountId) throws HieroException {
+    return mirrorNodeClient.querySchedulesByAccount(accountId);
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
@@ -2,6 +2,7 @@ package org.hiero.base.mirrornode;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
+import com.hedera.hashgraph.sdk.ScheduleId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
 import java.util.List;
@@ -21,6 +22,7 @@ import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftMetadata;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.Result;
+import org.hiero.base.data.Schedule;
 import org.hiero.base.data.Token;
 import org.hiero.base.data.TokenInfo;
 import org.hiero.base.data.Topic;
@@ -441,6 +443,60 @@ public interface MirrorNodeClient {
   @NonNull Page<NftMetadata> findNftTypesByOwner(@NonNull AccountId ownerId);
 
   @NonNull Page<NftMetadata> findAllNftTypes();
+
+  /**
+   * Queries all schedules.
+   *
+   * @return the schedules
+   * @throws HieroException if an error occurs
+   */
+  @NonNull Page<Schedule> querySchedules() throws HieroException;
+
+  /**
+   * Queries schedules involving a specific account.
+   *
+   * @param accountId the account ID
+   * @return the schedules involving the account
+   * @throws HieroException if an error occurs
+   */
+  @NonNull Page<Schedule> querySchedulesByAccount(@NonNull AccountId accountId)
+      throws HieroException;
+
+  /**
+   * Queries schedules involving a specific account.
+   *
+   * @param accountId the account ID
+   * @return the schedules involving the account
+   * @throws HieroException if an error occurs
+   */
+  @NonNull
+  default Page<Schedule> querySchedulesByAccount(@NonNull String accountId) throws HieroException {
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    return querySchedulesByAccount(AccountId.fromString(accountId));
+  }
+
+  /**
+   * Queries a schedule by its schedule ID.
+   *
+   * @param scheduleId the schedule ID
+   * @return the schedule information
+   * @throws HieroException if an error occurs
+   */
+  @NonNull Optional<Schedule> queryScheduleById(@NonNull ScheduleId scheduleId)
+      throws HieroException;
+
+  /**
+   * Queries a schedule by its schedule ID.
+   *
+   * @param scheduleId the schedule ID
+   * @return the schedule information
+   * @throws HieroException if an error occurs
+   */
+  @NonNull
+  default Optional<Schedule> queryScheduleById(@NonNull String scheduleId) throws HieroException {
+    Objects.requireNonNull(scheduleId, "scheduleId must not be null");
+    return queryScheduleById(ScheduleId.fromString(scheduleId));
+  }
 
   /**
    * Queries all contracts.

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/ScheduleRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/ScheduleRepository.java
@@ -1,0 +1,69 @@
+package org.hiero.base.mirrornode;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.ScheduleId;
+import java.util.Objects;
+import java.util.Optional;
+import org.hiero.base.HieroException;
+import org.hiero.base.data.Page;
+import org.hiero.base.data.Schedule;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Interface for interacting with scheduled transactions on a Hiero network. This interface provides
+ * methods for searching schedules.
+ */
+public interface ScheduleRepository {
+
+  /**
+   * Return all schedules.
+   *
+   * @return first page of schedules
+   * @throws HieroException if the search fails
+   */
+  @NonNull Page<Schedule> findAll() throws HieroException;
+
+  /**
+   * Return a schedule by its schedule ID.
+   *
+   * @param scheduleId id of the schedule
+   * @return {@link Optional} containing the found schedule
+   * @throws HieroException if the search fails
+   */
+  @NonNull Optional<Schedule> findById(@NonNull ScheduleId scheduleId) throws HieroException;
+
+  /**
+   * Return a schedule by its schedule ID.
+   *
+   * @param scheduleId id of the schedule
+   * @return {@link Optional} containing the found schedule
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  default Optional<Schedule> findById(@NonNull String scheduleId) throws HieroException {
+    Objects.requireNonNull(scheduleId, "scheduleId must not be null");
+    return findById(ScheduleId.fromString(scheduleId));
+  }
+
+  /**
+   * Return schedules involving an account.
+   *
+   * @param accountId id of the account
+   * @return first page of schedules
+   * @throws HieroException if the search fails
+   */
+  @NonNull Page<Schedule> findByAccountId(@NonNull AccountId accountId) throws HieroException;
+
+  /**
+   * Return schedules involving an account.
+   *
+   * @param accountId id of the account
+   * @return first page of schedules
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  default Page<Schedule> findByAccountId(@NonNull String accountId) throws HieroException {
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    return findByAccountId(AccountId.fromString(accountId));
+  }
+}

--- a/hiero-enterprise-base/src/test/java/org/hiero/base/test/ScheduleRepositoryImplTest.java
+++ b/hiero-enterprise-base/src/test/java/org/hiero/base/test/ScheduleRepositoryImplTest.java
@@ -1,0 +1,122 @@
+package org.hiero.base.test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.ScheduleId;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.hiero.base.HieroException;
+import org.hiero.base.data.Page;
+import org.hiero.base.data.Schedule;
+import org.hiero.base.data.ScheduleSignature;
+import org.hiero.base.data.SinglePage;
+import org.hiero.base.implementation.ScheduleRepositoryImpl;
+import org.hiero.base.mirrornode.MirrorNodeClient;
+import org.hiero.base.mirrornode.ScheduleRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ScheduleRepositoryImplTest {
+
+  private final MirrorNodeClient mirrorNodeClient = mock(MirrorNodeClient.class);
+  private final ScheduleRepository scheduleRepository =
+      new ScheduleRepositoryImpl(mirrorNodeClient);
+
+  @Test
+  void constructorRejectsNullMirrorNodeClient() {
+    Assertions.assertThrows(NullPointerException.class, () -> new ScheduleRepositoryImpl(null));
+  }
+
+  @Test
+  void findAllDelegatesToMirrorNodeClient() throws HieroException {
+    final Page<Schedule> expected = new SinglePage<>(List.of(schedule()));
+    when(mirrorNodeClient.querySchedules()).thenReturn(expected);
+
+    final Page<Schedule> result = scheduleRepository.findAll();
+
+    Assertions.assertSame(expected, result);
+    verify(mirrorNodeClient).querySchedules();
+  }
+
+  @Test
+  void findByIdDelegatesToMirrorNodeClient() throws HieroException {
+    final ScheduleId scheduleId = ScheduleId.fromString("0.0.7007");
+    final Optional<Schedule> expected = Optional.of(schedule());
+    when(mirrorNodeClient.queryScheduleById(scheduleId)).thenReturn(expected);
+
+    final Optional<Schedule> result = scheduleRepository.findById(scheduleId);
+
+    Assertions.assertSame(expected, result);
+    verify(mirrorNodeClient).queryScheduleById(scheduleId);
+  }
+
+  @Test
+  void findByIdStringConvertsAndDelegatesToMirrorNodeClient() throws HieroException {
+    final ScheduleId scheduleId = ScheduleId.fromString("0.0.7007");
+    final Optional<Schedule> expected = Optional.of(schedule());
+    when(mirrorNodeClient.queryScheduleById(scheduleId)).thenReturn(expected);
+
+    final Optional<Schedule> result = scheduleRepository.findById("0.0.7007");
+
+    Assertions.assertSame(expected, result);
+    verify(mirrorNodeClient).queryScheduleById(scheduleId);
+  }
+
+  @Test
+  void findByIdStringRejectsNull() {
+    Assertions.assertThrows(
+        NullPointerException.class, () -> scheduleRepository.findById((String) null));
+  }
+
+  @Test
+  void findByAccountIdDelegatesToMirrorNodeClient() throws HieroException {
+    final AccountId accountId = AccountId.fromString("0.0.1001");
+    final Page<Schedule> expected = new SinglePage<>(List.of(schedule()));
+    when(mirrorNodeClient.querySchedulesByAccount(accountId)).thenReturn(expected);
+
+    final Page<Schedule> result = scheduleRepository.findByAccountId(accountId);
+
+    Assertions.assertSame(expected, result);
+    verify(mirrorNodeClient).querySchedulesByAccount(accountId);
+  }
+
+  @Test
+  void findByAccountIdStringConvertsAndDelegatesToMirrorNodeClient() throws HieroException {
+    final AccountId accountId = AccountId.fromString("0.0.1001");
+    final Page<Schedule> expected = new SinglePage<>(List.of(schedule()));
+    when(mirrorNodeClient.querySchedulesByAccount(accountId)).thenReturn(expected);
+
+    final Page<Schedule> result = scheduleRepository.findByAccountId("0.0.1001");
+
+    Assertions.assertSame(expected, result);
+    verify(mirrorNodeClient).querySchedulesByAccount(accountId);
+  }
+
+  @Test
+  void findByAccountIdStringRejectsNull() {
+    Assertions.assertThrows(
+        NullPointerException.class, () -> scheduleRepository.findByAccountId((String) null));
+  }
+
+  private static Schedule schedule() {
+    return new Schedule(
+        ScheduleId.fromString("0.0.7007"),
+        null,
+        false,
+        Instant.ofEpochSecond(1_586_567_700L),
+        AccountId.fromString("0.0.1001"),
+        null,
+        Instant.ofEpochSecond(1_586_567_800L),
+        "scheduled transfer",
+        AccountId.fromString("0.0.1002"),
+        List.of(
+            new ScheduleSignature(
+                Instant.ofEpochSecond(1_586_567_701L), "0x01", "0x02", "ED25519")),
+        null,
+        false);
+  }
+}

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
@@ -24,6 +24,7 @@ import org.hiero.base.implementation.NetworkRepositoryImpl;
 import org.hiero.base.implementation.NftClientImpl;
 import org.hiero.base.implementation.NftRepositoryImpl;
 import org.hiero.base.implementation.ProtocolLayerClientImpl;
+import org.hiero.base.implementation.ScheduleRepositoryImpl;
 import org.hiero.base.implementation.SmartContractClientImpl;
 import org.hiero.base.implementation.TokenRepositoryImpl;
 import org.hiero.base.implementation.TopicClientImpl;
@@ -35,6 +36,7 @@ import org.hiero.base.mirrornode.ContractRepository;
 import org.hiero.base.mirrornode.MirrorNodeClient;
 import org.hiero.base.mirrornode.NetworkRepository;
 import org.hiero.base.mirrornode.NftRepository;
+import org.hiero.base.mirrornode.ScheduleRepository;
 import org.hiero.base.mirrornode.TokenRepository;
 import org.hiero.base.mirrornode.TopicRepository;
 import org.hiero.base.mirrornode.TransactionRepository;
@@ -207,5 +209,12 @@ public class ClientProvider {
   @ApplicationScoped
   TopicRepository createTopicRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
     return new TopicRepositoryImpl(mirrorNodeClient);
+  }
+
+  @NonNull
+  @Produces
+  @ApplicationScoped
+  ScheduleRepository createScheduleRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
+    return new ScheduleRepositoryImpl(mirrorNodeClient);
   }
 }

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -15,6 +15,7 @@ import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftMetadata;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.Result;
+import org.hiero.base.data.Schedule;
 import org.hiero.base.data.Token;
 import org.hiero.base.data.TopicMessage;
 import org.hiero.base.data.TransactionInfo;
@@ -140,6 +141,24 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
     final String path = "/api/v1/topics/" + topicId + "/messages";
     final Function<JsonObject, List<TopicMessage>> dataExtractionFunction =
         node -> jsonConverter.toTopicMessages(node);
+    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+  }
+
+  @Override
+  public @NonNull Page<Schedule> querySchedules() throws HieroException {
+    final String path = "/api/v1/schedules";
+    final Function<JsonObject, List<Schedule>> dataExtractionFunction =
+        node -> jsonConverter.toSchedules(node);
+    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+  }
+
+  @Override
+  public @NonNull Page<Schedule> querySchedulesByAccount(@NonNull AccountId accountId)
+      throws HieroException {
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    final String path = "/api/v1/schedules?account.id=" + accountId;
+    final Function<JsonObject, List<Schedule>> dataExtractionFunction =
+        node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
   }
 

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -27,6 +27,10 @@ import org.jspecify.annotations.NonNull;
 
 public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
+  private static final String SCHEDULES_PATH = "/api/v1/schedules";
+
+  private static final String ACCOUNT_ID_QUERY_PARAM = "?account.id=";
+
   private final MirrorNodeRestClientImpl restClient;
 
   private final MirrorNodeJsonConverter<JsonObject> jsonConverter;
@@ -146,17 +150,16 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
   @Override
   public @NonNull Page<Schedule> querySchedules() throws HieroException {
-    final String path = "/api/v1/schedules";
     final Function<JsonObject, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, SCHEDULES_PATH);
   }
 
   @Override
   public @NonNull Page<Schedule> querySchedulesByAccount(@NonNull AccountId accountId)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    final String path = "/api/v1/schedules?account.id=" + accountId;
+    final String path = SCHEDULES_PATH + ACCOUNT_ID_QUERY_PARAM + accountId;
     final Function<JsonObject, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -27,8 +27,6 @@ import org.jspecify.annotations.NonNull;
 
 public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
-  private static final String SCHEDULES_PATH = "/api/v1/schedules";
-
   private final MirrorNodeRestClientImpl restClient;
 
   private final MirrorNodeJsonConverter<JsonObject> jsonConverter;
@@ -148,16 +146,17 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
   @Override
   public @NonNull Page<Schedule> querySchedules() throws HieroException {
+    final String path = "/api/v1/schedules";
     final Function<JsonObject, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
-    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, SCHEDULES_PATH);
+    return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
   }
 
   @Override
   public @NonNull Page<Schedule> querySchedulesByAccount(@NonNull AccountId accountId)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    final String path = SCHEDULES_PATH + "?account.id=" + accountId;
+    final String path = "/api/v1/schedules?account.id=" + accountId;
     final Function<JsonObject, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -29,8 +29,6 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
   private static final String SCHEDULES_PATH = "/api/v1/schedules";
 
-  private static final String ACCOUNT_ID_QUERY_PARAM = "?account.id=";
-
   private final MirrorNodeRestClientImpl restClient;
 
   private final MirrorNodeJsonConverter<JsonObject> jsonConverter;
@@ -159,7 +157,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
   public @NonNull Page<Schedule> querySchedulesByAccount(@NonNull AccountId accountId)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    final String path = SCHEDULES_PATH + ACCOUNT_ID_QUERY_PARAM + accountId;
+    final String path = SCHEDULES_PATH + "?account.id=" + accountId;
     final Function<JsonObject, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
@@ -3,6 +3,7 @@ package org.hiero.microprofile.implementation;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.ScheduleId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TokenSupplyType;
 import com.hedera.hashgraph.sdk.TokenType;
@@ -38,6 +39,8 @@ import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftTransfer;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.RoyaltyFee;
+import org.hiero.base.data.Schedule;
+import org.hiero.base.data.ScheduleSignature;
 import org.hiero.base.data.SinglePage;
 import org.hiero.base.data.StakingRewardTransfer;
 import org.hiero.base.data.TimestampRange;
@@ -948,6 +951,34 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
   }
 
   @Override
+  public @NonNull Optional<Schedule> toSchedule(@NonNull JsonObject jsonObject) {
+    Objects.requireNonNull(jsonObject, "jsonObject must not be null");
+    if (jsonObject.isEmpty()) {
+      return Optional.empty();
+    }
+
+    try {
+      final String transactionBody = stringOrNull(jsonObject, "transaction_body");
+      return Optional.of(
+          new Schedule(
+              ScheduleId.fromString(jsonObject.getString("schedule_id")),
+              publicKeyOrNull(jsonObject, "admin_key"),
+              jsonObject.getBoolean("deleted"),
+              parseTimestamp(jsonObject.getString("consensus_timestamp")),
+              AccountId.fromString(jsonObject.getString("creator_account_id")),
+              timestampOrNull(jsonObject, "executed_timestamp"),
+              timestampOrNull(jsonObject, "expiration_time"),
+              jsonObject.getString("memo"),
+              accountIdOrNull(jsonObject, "payer_account_id"),
+              scheduleSignatures(jsonObject.getJsonArray("signatures")),
+              transactionBody == null ? null : Base64.getDecoder().decode(transactionBody),
+              jsonObject.getBoolean("wait_for_expiry")));
+    } catch (final Exception e) {
+      throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
+    }
+  }
+
+  @Override
   public @NonNull List<Block> toBlocks(@NonNull JsonObject jsonObject) {
     Objects.requireNonNull(jsonObject, "jsonObject must not be null");
     if (!jsonObject.containsKey("blocks")) {
@@ -964,5 +995,104 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
         .filter(Optional::isPresent)
         .map(Optional::get)
         .toList();
+  }
+
+  @Override
+  public @NonNull Page<Schedule> toSchedulePage(@NonNull JsonObject jsonObject) {
+    Objects.requireNonNull(jsonObject, "jsonObject must not be null");
+    if (jsonObject.isEmpty()) {
+      return new SinglePage<>(List.of());
+    }
+
+    try {
+      return new SinglePage<>(toSchedules(jsonObject));
+    } catch (final Exception e) {
+      throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
+    }
+  }
+
+  @Override
+  public @NonNull List<Schedule> toSchedules(@NonNull JsonObject jsonObject) {
+    Objects.requireNonNull(jsonObject, "jsonObject must not be null");
+    if (!jsonObject.containsKey("schedules")) {
+      return List.of();
+    }
+    final JsonArray schedulesArray = jsonObject.getJsonArray("schedules");
+    if (schedulesArray == null) {
+      throw new IllegalArgumentException("No schedules array in JSON");
+    }
+    if (schedulesArray.isEmpty()) {
+      return List.of();
+    }
+    return jsonArrayToStream(schedulesArray)
+        .map(n -> toSchedule(n.asJsonObject()))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .toList();
+  }
+
+  private Optional<ScheduleSignature> toScheduleSignature(@NonNull JsonObject jsonObject) {
+    Objects.requireNonNull(jsonObject, "jsonObject must not be null");
+    if (jsonObject.isEmpty()) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(
+          new ScheduleSignature(
+              parseTimestamp(jsonObject.getString("consensus_timestamp")),
+              jsonObject.getString("public_key_prefix"),
+              jsonObject.getString("signature"),
+              jsonObject.getString("type")));
+    } catch (final Exception e) {
+      throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
+    }
+  }
+
+  private List<ScheduleSignature> scheduleSignatures(final JsonArray jsonArray) {
+    if (jsonArray == null || jsonArray.isEmpty()) {
+      return List.of();
+    }
+    return jsonArrayToStream(jsonArray)
+        .map(n -> toScheduleSignature(n.asJsonObject()))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .toList();
+  }
+
+  private PublicKey publicKeyOrNull(@NonNull JsonObject jsonObject, @NonNull String fieldName) {
+    if (!jsonObject.containsKey(fieldName) || jsonObject.isNull(fieldName)) {
+      return null;
+    }
+    return PublicKey.fromString(jsonObject.getJsonObject(fieldName).getString("key"));
+  }
+
+  private AccountId accountIdOrNull(@NonNull JsonObject jsonObject, @NonNull String fieldName) {
+    final String value = stringOrNull(jsonObject, fieldName);
+    return value == null ? null : AccountId.fromString(value);
+  }
+
+  private String stringOrNull(@NonNull JsonObject jsonObject, @NonNull String fieldName) {
+    if (!jsonObject.containsKey(fieldName) || jsonObject.isNull(fieldName)) {
+      return null;
+    }
+    return jsonObject.getString(fieldName);
+  }
+
+  private Instant timestampOrNull(@NonNull JsonObject jsonObject, @NonNull String fieldName) {
+    final String value = stringOrNull(jsonObject, fieldName);
+    return value == null ? null : parseTimestamp(value);
+  }
+
+  private Instant parseTimestamp(@NonNull String value) {
+    final String[] parts = value.split("\\.", 2);
+    final long seconds = Long.parseLong(parts[0]);
+    final int nanos;
+    if (parts.length == 1) {
+      nanos = 0;
+    } else {
+      final String paddedNanos = (parts[1] + "000000000").substring(0, 9);
+      nanos = Integer.parseInt(paddedNanos);
+    }
+    return Instant.ofEpochSecond(seconds, nanos);
   }
 }

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
@@ -57,6 +57,24 @@ import org.jspecify.annotations.NonNull;
 
 public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<JsonObject> {
 
+  private static final String ADMIN_KEY = "admin_key";
+  private static final String CONSENSUS_TIMESTAMP = "consensus_timestamp";
+  private static final String CREATOR_ACCOUNT_ID = "creator_account_id";
+  private static final String DELETED = "deleted";
+  private static final String EXECUTED_TIMESTAMP = "executed_timestamp";
+  private static final String EXPIRATION_TIME = "expiration_time";
+  private static final String KEY = "key";
+  private static final String MEMO = "memo";
+  private static final String PAYER_ACCOUNT_ID = "payer_account_id";
+  private static final String PUBLIC_KEY_PREFIX = "public_key_prefix";
+  private static final String SCHEDULE_ID = "schedule_id";
+  private static final String SCHEDULES = "schedules";
+  private static final String SIGNATURE = "signature";
+  private static final String SIGNATURES = "signatures";
+  private static final String TRANSACTION_BODY = "transaction_body";
+  private static final String TYPE = "type";
+  private static final String WAIT_FOR_EXPIRY = "wait_for_expiry";
+
   @Override
   public @NonNull Optional<Nft> toNft(@NonNull JsonObject jsonObject) {
     if (jsonObject.isEmpty() || jsonObject.containsKey("_status")) {
@@ -958,21 +976,21 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     }
 
     try {
-      final String transactionBody = stringOrNull(jsonObject, "transaction_body");
+      final String transactionBody = stringOrNull(jsonObject, TRANSACTION_BODY);
       return Optional.of(
           new Schedule(
-              ScheduleId.fromString(jsonObject.getString("schedule_id")),
-              publicKeyOrNull(jsonObject, "admin_key"),
-              jsonObject.getBoolean("deleted"),
-              parseTimestamp(jsonObject.getString("consensus_timestamp")),
-              AccountId.fromString(jsonObject.getString("creator_account_id")),
-              timestampOrNull(jsonObject, "executed_timestamp"),
-              timestampOrNull(jsonObject, "expiration_time"),
-              jsonObject.getString("memo"),
-              accountIdOrNull(jsonObject, "payer_account_id"),
-              scheduleSignatures(jsonObject.getJsonArray("signatures")),
+              ScheduleId.fromString(jsonObject.getString(SCHEDULE_ID)),
+              publicKeyOrNull(jsonObject, ADMIN_KEY),
+              jsonObject.getBoolean(DELETED),
+              parseTimestamp(jsonObject.getString(CONSENSUS_TIMESTAMP)),
+              AccountId.fromString(jsonObject.getString(CREATOR_ACCOUNT_ID)),
+              timestampOrNull(jsonObject, EXECUTED_TIMESTAMP),
+              timestampOrNull(jsonObject, EXPIRATION_TIME),
+              jsonObject.getString(MEMO),
+              accountIdOrNull(jsonObject, PAYER_ACCOUNT_ID),
+              scheduleSignatures(jsonObject.getJsonArray(SIGNATURES)),
               transactionBody == null ? null : Base64.getDecoder().decode(transactionBody),
-              jsonObject.getBoolean("wait_for_expiry")));
+              jsonObject.getBoolean(WAIT_FOR_EXPIRY)));
     } catch (final Exception e) {
       throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
     }
@@ -1014,10 +1032,10 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
   @Override
   public @NonNull List<Schedule> toSchedules(@NonNull JsonObject jsonObject) {
     Objects.requireNonNull(jsonObject, "jsonObject must not be null");
-    if (!jsonObject.containsKey("schedules")) {
+    if (!jsonObject.containsKey(SCHEDULES)) {
       return List.of();
     }
-    final JsonArray schedulesArray = jsonObject.getJsonArray("schedules");
+    final JsonArray schedulesArray = jsonObject.getJsonArray(SCHEDULES);
     if (schedulesArray == null) {
       throw new IllegalArgumentException("No schedules array in JSON");
     }
@@ -1039,10 +1057,10 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     try {
       return Optional.of(
           new ScheduleSignature(
-              parseTimestamp(jsonObject.getString("consensus_timestamp")),
-              jsonObject.getString("public_key_prefix"),
-              jsonObject.getString("signature"),
-              jsonObject.getString("type")));
+              parseTimestamp(jsonObject.getString(CONSENSUS_TIMESTAMP)),
+              jsonObject.getString(PUBLIC_KEY_PREFIX),
+              jsonObject.getString(SIGNATURE),
+              jsonObject.getString(TYPE)));
     } catch (final Exception e) {
       throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
     }
@@ -1063,7 +1081,7 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     if (!jsonObject.containsKey(fieldName) || jsonObject.isNull(fieldName)) {
       return null;
     }
-    return PublicKey.fromString(jsonObject.getJsonObject(fieldName).getString("key"));
+    return PublicKey.fromString(jsonObject.getJsonObject(fieldName).getString(KEY));
   }
 
   private AccountId accountIdOrNull(@NonNull JsonObject jsonObject, @NonNull String fieldName) {

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
@@ -57,24 +57,6 @@ import org.jspecify.annotations.NonNull;
 
 public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<JsonObject> {
 
-  private static final String ADMIN_KEY = "admin_key";
-  private static final String CONSENSUS_TIMESTAMP = "consensus_timestamp";
-  private static final String CREATOR_ACCOUNT_ID = "creator_account_id";
-  private static final String DELETED = "deleted";
-  private static final String EXECUTED_TIMESTAMP = "executed_timestamp";
-  private static final String EXPIRATION_TIME = "expiration_time";
-  private static final String KEY = "key";
-  private static final String MEMO = "memo";
-  private static final String PAYER_ACCOUNT_ID = "payer_account_id";
-  private static final String PUBLIC_KEY_PREFIX = "public_key_prefix";
-  private static final String SCHEDULE_ID = "schedule_id";
-  private static final String SCHEDULES = "schedules";
-  private static final String SIGNATURE = "signature";
-  private static final String SIGNATURES = "signatures";
-  private static final String TRANSACTION_BODY = "transaction_body";
-  private static final String TYPE = "type";
-  private static final String WAIT_FOR_EXPIRY = "wait_for_expiry";
-
   @Override
   public @NonNull Optional<Nft> toNft(@NonNull JsonObject jsonObject) {
     if (jsonObject.isEmpty() || jsonObject.containsKey("_status")) {
@@ -976,21 +958,21 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     }
 
     try {
-      final String transactionBody = stringOrNull(jsonObject, TRANSACTION_BODY);
+      final String transactionBody = stringOrNull(jsonObject, "transaction_body");
       return Optional.of(
           new Schedule(
-              ScheduleId.fromString(jsonObject.getString(SCHEDULE_ID)),
-              publicKeyOrNull(jsonObject, ADMIN_KEY),
-              jsonObject.getBoolean(DELETED),
-              parseTimestamp(jsonObject.getString(CONSENSUS_TIMESTAMP)),
-              AccountId.fromString(jsonObject.getString(CREATOR_ACCOUNT_ID)),
-              timestampOrNull(jsonObject, EXECUTED_TIMESTAMP),
-              timestampOrNull(jsonObject, EXPIRATION_TIME),
-              jsonObject.getString(MEMO),
-              accountIdOrNull(jsonObject, PAYER_ACCOUNT_ID),
-              scheduleSignatures(jsonObject.getJsonArray(SIGNATURES)),
+              ScheduleId.fromString(jsonObject.getString("schedule_id")),
+              publicKeyOrNull(jsonObject, "admin_key"),
+              jsonObject.getBoolean("deleted"),
+              parseTimestamp(jsonObject.getString("consensus_timestamp")),
+              AccountId.fromString(jsonObject.getString("creator_account_id")),
+              timestampOrNull(jsonObject, "executed_timestamp"),
+              timestampOrNull(jsonObject, "expiration_time"),
+              jsonObject.getString("memo"),
+              accountIdOrNull(jsonObject, "payer_account_id"),
+              scheduleSignatures(jsonObject.getJsonArray("signatures")),
               transactionBody == null ? null : Base64.getDecoder().decode(transactionBody),
-              jsonObject.getBoolean(WAIT_FOR_EXPIRY)));
+              jsonObject.getBoolean("wait_for_expiry")));
     } catch (final Exception e) {
       throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
     }
@@ -1032,10 +1014,10 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
   @Override
   public @NonNull List<Schedule> toSchedules(@NonNull JsonObject jsonObject) {
     Objects.requireNonNull(jsonObject, "jsonObject must not be null");
-    if (!jsonObject.containsKey(SCHEDULES)) {
+    if (!jsonObject.containsKey("schedules")) {
       return List.of();
     }
-    final JsonArray schedulesArray = jsonObject.getJsonArray(SCHEDULES);
+    final JsonArray schedulesArray = jsonObject.getJsonArray("schedules");
     if (schedulesArray == null) {
       throw new IllegalArgumentException("No schedules array in JSON");
     }
@@ -1057,10 +1039,10 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     try {
       return Optional.of(
           new ScheduleSignature(
-              parseTimestamp(jsonObject.getString(CONSENSUS_TIMESTAMP)),
-              jsonObject.getString(PUBLIC_KEY_PREFIX),
-              jsonObject.getString(SIGNATURE),
-              jsonObject.getString(TYPE)));
+              parseTimestamp(jsonObject.getString("consensus_timestamp")),
+              jsonObject.getString("public_key_prefix"),
+              jsonObject.getString("signature"),
+              jsonObject.getString("type")));
     } catch (final Exception e) {
       throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
     }
@@ -1081,7 +1063,7 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     if (!jsonObject.containsKey(fieldName) || jsonObject.isNull(fieldName)) {
       return null;
     }
-    return PublicKey.fromString(jsonObject.getJsonObject(fieldName).getString(KEY));
+    return PublicKey.fromString(jsonObject.getJsonObject(fieldName).getString("key"));
   }
 
   private AccountId accountIdOrNull(@NonNull JsonObject jsonObject, @NonNull String fieldName) {

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeJsonConverterImplScheduleTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeJsonConverterImplScheduleTest.java
@@ -1,0 +1,124 @@
+package org.hiero.microprofile.test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.ScheduleId;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import org.hiero.base.data.Schedule;
+import org.hiero.microprofile.implementation.MirrorNodeJsonConverterImpl;
+import org.junit.jupiter.api.Test;
+
+class MirrorNodeJsonConverterImplScheduleTest {
+
+  private final MirrorNodeJsonConverterImpl converter = new MirrorNodeJsonConverterImpl();
+
+  @Test
+  void toSchedulesReturnsEmptyWhenKeyMissing() {
+    final JsonObject jsonObject = parse("{\"links\":{\"next\":null}}");
+
+    final List<Schedule> result = converter.toSchedules(jsonObject);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void toSchedulesReturnsEmptyForEmptyArray() {
+    final JsonObject jsonObject = parse("{\"schedules\":[],\"links\":{\"next\":null}}");
+
+    final List<Schedule> result = converter.toSchedules(jsonObject);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void toSchedulesParsesSingleEntry() {
+    final JsonObject jsonObject = parse(schedulesJson());
+
+    final List<Schedule> result = converter.toSchedules(jsonObject);
+
+    assertEquals(1, result.size());
+    assertSchedule(result.get(0));
+  }
+
+  @Test
+  void toScheduleParsesSingleEntry() {
+    final JsonObject jsonObject = parse(scheduleJson());
+
+    final Schedule schedule = converter.toSchedule(jsonObject).orElseThrow();
+
+    assertSchedule(schedule);
+  }
+
+  private static void assertSchedule(final Schedule schedule) {
+    assertEquals(ScheduleId.fromString("0.0.7007"), schedule.scheduleId());
+    assertNull(schedule.adminKey());
+    assertFalse(schedule.deleted());
+    assertEquals(Instant.ofEpochSecond(1_586_567_700L, 453_054_000), schedule.consensusTimestamp());
+    assertEquals(AccountId.fromString("0.0.1001"), schedule.creatorAccountId());
+    assertNull(schedule.executedTimestamp());
+    assertEquals(Instant.ofEpochSecond(1_586_567_800L, 1), schedule.expirationTime());
+    assertEquals("scheduled transfer", schedule.memo());
+    assertEquals(AccountId.fromString("0.0.1002"), schedule.payerAccountId());
+    assertArrayEquals("test-body".getBytes(StandardCharsets.UTF_8), schedule.transactionBody());
+    assertFalse(schedule.waitForExpiry());
+    assertEquals(1, schedule.signatures().size());
+    assertEquals(
+        Instant.ofEpochSecond(1_586_567_710L, 111_222_333),
+        schedule.signatures().get(0).consensusTimestamp());
+    assertEquals("0x0102", schedule.signatures().get(0).publicKeyPrefix());
+    assertEquals("0x0304", schedule.signatures().get(0).signature());
+    assertEquals("ED25519", schedule.signatures().get(0).type());
+  }
+
+  private static JsonObject parse(final String json) {
+    return Json.createReader(new StringReader(json)).readObject();
+  }
+
+  private static String schedulesJson() {
+    return """
+        {
+          "schedules": [
+            %s
+          ],
+          "links": {"next": null}
+        }
+        """
+        .formatted(scheduleJson());
+  }
+
+  private static String scheduleJson() {
+    return """
+        {
+          "admin_key": null,
+          "deleted": false,
+          "consensus_timestamp": "1586567700.453054000",
+          "creator_account_id": "0.0.1001",
+          "executed_timestamp": null,
+          "expiration_time": "1586567800.000000001",
+          "memo": "scheduled transfer",
+          "payer_account_id": "0.0.1002",
+          "schedule_id": "0.0.7007",
+          "signatures": [
+            {
+              "consensus_timestamp": "1586567710.111222333",
+              "public_key_prefix": "0x0102",
+              "signature": "0x0304",
+              "type": "ED25519"
+            }
+          ],
+          "transaction_body": "dGVzdC1ib2R5",
+          "wait_for_expiry": false
+        }
+        """;
+  }
+}

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/ScheduleRepositoryTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/ScheduleRepositoryTest.java
@@ -1,0 +1,70 @@
+package org.hiero.microprofile.test;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.ScheduleId;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.Configuration;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.hiero.base.data.Page;
+import org.hiero.base.data.Schedule;
+import org.hiero.base.mirrornode.ScheduleRepository;
+import org.hiero.microprofile.ClientProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@HelidonTest
+@AddBean(ClientProvider.class)
+@Configuration(useExisting = true)
+public class ScheduleRepositoryTest {
+
+  @Inject private ScheduleRepository scheduleRepository;
+
+  @BeforeAll
+  static void setup() {
+    final Config build =
+        ConfigProviderResolver.instance().getBuilder().withSources(new TestConfigSource()).build();
+    ConfigProviderResolver.instance()
+        .registerConfig(build, Thread.currentThread().getContextClassLoader());
+  }
+
+  @Test
+  void testNullParam() {
+    Assertions.assertThrows(
+        NullPointerException.class, () -> scheduleRepository.findById((String) null));
+    Assertions.assertThrows(
+        NullPointerException.class, () -> scheduleRepository.findByAccountId((String) null));
+  }
+
+  @Test
+  void testFindAll() throws Exception {
+    final Page<Schedule> result = scheduleRepository.findAll();
+
+    Assertions.assertNotNull(result);
+    Assertions.assertNotNull(result.getData());
+  }
+
+  @Test
+  void testFindByIdReturnsEmptyOptionalForInvalidId() throws Exception {
+    final ScheduleId scheduleId = ScheduleId.fromString("1.2.3");
+
+    final Optional<Schedule> result = scheduleRepository.findById(scheduleId);
+
+    Assertions.assertNotNull(result);
+    Assertions.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testFindByAccountIdReturnsEmptyListForAccountWithoutSchedules() throws Exception {
+    final AccountId accountId = AccountId.fromString("1.2.3");
+
+    final Page<Schedule> result = scheduleRepository.findByAccountId(accountId);
+
+    Assertions.assertNotNull(result);
+    Assertions.assertTrue(result.getData().isEmpty());
+  }
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -23,6 +23,7 @@ import org.hiero.base.implementation.NetworkRepositoryImpl;
 import org.hiero.base.implementation.NftClientImpl;
 import org.hiero.base.implementation.NftRepositoryImpl;
 import org.hiero.base.implementation.ProtocolLayerClientImpl;
+import org.hiero.base.implementation.ScheduleRepositoryImpl;
 import org.hiero.base.implementation.SmartContractClientImpl;
 import org.hiero.base.implementation.TokenRepositoryImpl;
 import org.hiero.base.implementation.TopicClientImpl;
@@ -35,6 +36,7 @@ import org.hiero.base.mirrornode.ContractRepository;
 import org.hiero.base.mirrornode.MirrorNodeClient;
 import org.hiero.base.mirrornode.NetworkRepository;
 import org.hiero.base.mirrornode.NftRepository;
+import org.hiero.base.mirrornode.ScheduleRepository;
 import org.hiero.base.mirrornode.TokenRepository;
 import org.hiero.base.mirrornode.TopicRepository;
 import org.hiero.base.mirrornode.TransactionRepository;
@@ -231,6 +233,16 @@ public class HieroAutoConfiguration {
       matchIfMissing = true)
   TopicRepository topicRepository(final MirrorNodeClient mirrorNodeClient) {
     return new TopicRepositoryImpl(mirrorNodeClient);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "spring.hiero",
+      name = "mirrorNodeSupported",
+      havingValue = "true",
+      matchIfMissing = true)
+  ScheduleRepository scheduleRepository(final MirrorNodeClient mirrorNodeClient) {
+    return new ScheduleRepositoryImpl(mirrorNodeClient);
   }
 
   @Bean

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
@@ -29,8 +29,6 @@ import org.springframework.web.client.RestClient;
 
 public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
 
-  private static final String SCHEDULES_PATH = "/api/v1/schedules";
-
   private final ObjectMapper objectMapper;
 
   private final RestClient restClient;
@@ -179,17 +177,18 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
 
   @Override
   public @NonNull Page<Schedule> querySchedules() throws HieroException {
+    final String path = "/api/v1/schedules";
     final Function<JsonNode, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(
-        objectMapper, restClient.mutate().clone(), SCHEDULES_PATH, dataExtractionFunction);
+        objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
   }
 
   @Override
   public @NonNull Page<Schedule> querySchedulesByAccount(@NonNull AccountId accountId)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    final String path = SCHEDULES_PATH + "?account.id=" + accountId;
+    final String path = "/api/v1/schedules?account.id=" + accountId;
     final Function<JsonNode, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
@@ -29,6 +29,10 @@ import org.springframework.web.client.RestClient;
 
 public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
 
+  private static final String SCHEDULES_PATH = "/api/v1/schedules";
+
+  private static final String ACCOUNT_ID_QUERY_PARAM = "?account.id=";
+
   private final ObjectMapper objectMapper;
 
   private final RestClient restClient;
@@ -177,18 +181,17 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
 
   @Override
   public @NonNull Page<Schedule> querySchedules() throws HieroException {
-    final String path = "/api/v1/schedules";
     final Function<JsonNode, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(
-        objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
+        objectMapper, restClient.mutate().clone(), SCHEDULES_PATH, dataExtractionFunction);
   }
 
   @Override
   public @NonNull Page<Schedule> querySchedulesByAccount(@NonNull AccountId accountId)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    final String path = "/api/v1/schedules?account.id=" + accountId;
+    final String path = SCHEDULES_PATH + ACCOUNT_ID_QUERY_PARAM + accountId;
     final Function<JsonNode, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
@@ -16,6 +16,7 @@ import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftMetadata;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.Result;
+import org.hiero.base.data.Schedule;
 import org.hiero.base.data.Token;
 import org.hiero.base.data.TopicMessage;
 import org.hiero.base.data.TransactionInfo;
@@ -170,6 +171,26 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
     final String path = "/api/v1/topics/" + topicId + "/messages";
     final Function<JsonNode, List<TopicMessage>> dataExtractionFunction =
         node -> jsonConverter.toTopicMessages(node);
+    return new RestBasedPage<>(
+        objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
+  }
+
+  @Override
+  public @NonNull Page<Schedule> querySchedules() throws HieroException {
+    final String path = "/api/v1/schedules";
+    final Function<JsonNode, List<Schedule>> dataExtractionFunction =
+        node -> jsonConverter.toSchedules(node);
+    return new RestBasedPage<>(
+        objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
+  }
+
+  @Override
+  public @NonNull Page<Schedule> querySchedulesByAccount(@NonNull AccountId accountId)
+      throws HieroException {
+    Objects.requireNonNull(accountId, "accountId must not be null");
+    final String path = "/api/v1/schedules?account.id=" + accountId;
+    final Function<JsonNode, List<Schedule>> dataExtractionFunction =
+        node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(
         objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
   }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
@@ -31,8 +31,6 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
 
   private static final String SCHEDULES_PATH = "/api/v1/schedules";
 
-  private static final String ACCOUNT_ID_QUERY_PARAM = "?account.id=";
-
   private final ObjectMapper objectMapper;
 
   private final RestClient restClient;
@@ -191,7 +189,7 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
   public @NonNull Page<Schedule> querySchedulesByAccount(@NonNull AccountId accountId)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    final String path = SCHEDULES_PATH + ACCOUNT_ID_QUERY_PARAM + accountId;
+    final String path = SCHEDULES_PATH + "?account.id=" + accountId;
     final Function<JsonNode, List<Schedule>> dataExtractionFunction =
         node -> jsonConverter.toSchedules(node);
     return new RestBasedPage<>(

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
@@ -6,6 +6,7 @@ import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.DelegateContractId;
 import com.hedera.hashgraph.sdk.Key;
 import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.ScheduleId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TokenSupplyType;
 import com.hedera.hashgraph.sdk.TokenType;
@@ -39,6 +40,8 @@ import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftTransfer;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.RoyaltyFee;
+import org.hiero.base.data.Schedule;
+import org.hiero.base.data.ScheduleSignature;
 import org.hiero.base.data.SinglePage;
 import org.hiero.base.data.StakingRewardTransfer;
 import org.hiero.base.data.TimestampRange;
@@ -855,6 +858,133 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
         .filter(optional -> optional.isPresent())
         .map(optional -> optional.get())
         .toList();
+  }
+
+  @Override
+  public @NonNull Optional<Schedule> toSchedule(@NonNull JsonNode node) {
+    Objects.requireNonNull(node, "jsonNode must not be null");
+    if (node.isNull() || node.isEmpty()) {
+      return Optional.empty();
+    }
+
+    try {
+      final byte[] transactionBody =
+          node.get("transaction_body").isNull()
+              ? null
+              : Base64.getDecoder().decode(node.get("transaction_body").asText());
+      return Optional.of(
+          new Schedule(
+              ScheduleId.fromString(node.get("schedule_id").asText()),
+              publicKeyOrNull(node, "admin_key"),
+              node.get("deleted").asBoolean(),
+              parseTimestamp(node.get("consensus_timestamp").asText()),
+              AccountId.fromString(node.get("creator_account_id").asText()),
+              timestampOrNull(node, "executed_timestamp"),
+              timestampOrNull(node, "expiration_time"),
+              node.get("memo").asText(),
+              accountIdOrNull(node, "payer_account_id"),
+              scheduleSignatures(node.get("signatures")),
+              transactionBody,
+              node.get("wait_for_expiry").asBoolean()));
+    } catch (final Exception e) {
+      throw new JsonParseException(node, e);
+    }
+  }
+
+  @Override
+  public @NonNull Page<Schedule> toSchedulePage(@NonNull JsonNode node) {
+    Objects.requireNonNull(node, "jsonNode must not be null");
+    if (node.isNull() || node.isEmpty()) {
+      return new SinglePage<>(List.of());
+    }
+
+    try {
+      return new SinglePage<>(toSchedules(node));
+    } catch (final Exception e) {
+      throw new JsonParseException(node, e);
+    }
+  }
+
+  @Override
+  public @NonNull List<Schedule> toSchedules(@NonNull JsonNode node) {
+    Objects.requireNonNull(node, "jsonNode must not be null");
+    if (!node.has("schedules")) {
+      return List.of();
+    }
+    final JsonNode schedulesNode = node.get("schedules");
+    if (!schedulesNode.isArray()) {
+      throw new IllegalArgumentException("Schedules node is not an array: " + schedulesNode);
+    }
+    return jsonArrayToStream(schedulesNode)
+        .map(n -> toSchedule(n))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .toList();
+  }
+
+  private Optional<ScheduleSignature> toScheduleSignature(@NonNull JsonNode node) {
+    Objects.requireNonNull(node, "jsonNode must not be null");
+    if (node.isNull() || node.isEmpty()) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(
+          new ScheduleSignature(
+              parseTimestamp(node.get("consensus_timestamp").asText()),
+              node.get("public_key_prefix").asText(),
+              node.get("signature").asText(),
+              node.get("type").asText()));
+    } catch (final Exception e) {
+      throw new JsonParseException(node, e);
+    }
+  }
+
+  private List<ScheduleSignature> scheduleSignatures(final JsonNode node) {
+    if (node == null || node.isNull() || !node.isArray()) {
+      return List.of();
+    }
+    return jsonArrayToStream(node)
+        .map(n -> toScheduleSignature(n))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .toList();
+  }
+
+  private PublicKey publicKeyOrNull(@NonNull JsonNode node, @NonNull String fieldName) {
+    final JsonNode field = node.get(fieldName);
+    if (field == null || field.isNull()) {
+      return null;
+    }
+    return PublicKey.fromString(field.get("key").asText());
+  }
+
+  private AccountId accountIdOrNull(@NonNull JsonNode node, @NonNull String fieldName) {
+    final JsonNode field = node.get(fieldName);
+    if (field == null || field.isNull()) {
+      return null;
+    }
+    return AccountId.fromString(field.asText());
+  }
+
+  private Instant timestampOrNull(@NonNull JsonNode node, @NonNull String fieldName) {
+    final JsonNode field = node.get(fieldName);
+    if (field == null || field.isNull()) {
+      return null;
+    }
+    return parseTimestamp(field.asText());
+  }
+
+  private Instant parseTimestamp(@NonNull String value) {
+    final String[] parts = value.split("\\.", 2);
+    final long seconds = Long.parseLong(parts[0]);
+    final int nanos;
+    if (parts.length == 1) {
+      nanos = 0;
+    } else {
+      final String paddedNanos = (parts[1] + "000000000").substring(0, 9);
+      nanos = Integer.parseInt(paddedNanos);
+    }
+    return Instant.ofEpochSecond(seconds, nanos);
   }
 
   private @NonNull Key parseProtoBufEncodedKey(@NonNull String key) throws Exception {

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
@@ -58,24 +58,6 @@ import org.jspecify.annotations.NonNull;
 
 public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<JsonNode> {
 
-  private static final String ADMIN_KEY = "admin_key";
-  private static final String CONSENSUS_TIMESTAMP = "consensus_timestamp";
-  private static final String CREATOR_ACCOUNT_ID = "creator_account_id";
-  private static final String DELETED = "deleted";
-  private static final String EXECUTED_TIMESTAMP = "executed_timestamp";
-  private static final String EXPIRATION_TIME = "expiration_time";
-  private static final String KEY = "key";
-  private static final String MEMO = "memo";
-  private static final String PAYER_ACCOUNT_ID = "payer_account_id";
-  private static final String PUBLIC_KEY_PREFIX = "public_key_prefix";
-  private static final String SCHEDULE_ID = "schedule_id";
-  private static final String SCHEDULES = "schedules";
-  private static final String SIGNATURE = "signature";
-  private static final String SIGNATURES = "signatures";
-  private static final String TRANSACTION_BODY = "transaction_body";
-  private static final String TYPE = "type";
-  private static final String WAIT_FOR_EXPIRY = "wait_for_expiry";
-
   @Override
   public Optional<Nft> toNft(final JsonNode node) {
     Objects.requireNonNull(node, "jsonNode must not be null");
@@ -887,23 +869,23 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
 
     try {
       final byte[] transactionBody =
-          node.get(TRANSACTION_BODY).isNull()
+          node.get("transaction_body").isNull()
               ? null
-              : Base64.getDecoder().decode(node.get(TRANSACTION_BODY).asText());
+              : Base64.getDecoder().decode(node.get("transaction_body").asText());
       return Optional.of(
           new Schedule(
-              ScheduleId.fromString(node.get(SCHEDULE_ID).asText()),
-              publicKeyOrNull(node, ADMIN_KEY),
-              node.get(DELETED).asBoolean(),
-              parseTimestamp(node.get(CONSENSUS_TIMESTAMP).asText()),
-              AccountId.fromString(node.get(CREATOR_ACCOUNT_ID).asText()),
-              timestampOrNull(node, EXECUTED_TIMESTAMP),
-              timestampOrNull(node, EXPIRATION_TIME),
-              node.get(MEMO).asText(),
-              accountIdOrNull(node, PAYER_ACCOUNT_ID),
-              scheduleSignatures(node.get(SIGNATURES)),
+              ScheduleId.fromString(node.get("schedule_id").asText()),
+              publicKeyOrNull(node, "admin_key"),
+              node.get("deleted").asBoolean(),
+              parseTimestamp(node.get("consensus_timestamp").asText()),
+              AccountId.fromString(node.get("creator_account_id").asText()),
+              timestampOrNull(node, "executed_timestamp"),
+              timestampOrNull(node, "expiration_time"),
+              node.get("memo").asText(),
+              accountIdOrNull(node, "payer_account_id"),
+              scheduleSignatures(node.get("signatures")),
               transactionBody,
-              node.get(WAIT_FOR_EXPIRY).asBoolean()));
+              node.get("wait_for_expiry").asBoolean()));
     } catch (final Exception e) {
       throw new JsonParseException(node, e);
     }
@@ -926,10 +908,10 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
   @Override
   public @NonNull List<Schedule> toSchedules(@NonNull JsonNode node) {
     Objects.requireNonNull(node, "jsonNode must not be null");
-    if (!node.has(SCHEDULES)) {
+    if (!node.has("schedules")) {
       return List.of();
     }
-    final JsonNode schedulesNode = node.get(SCHEDULES);
+    final JsonNode schedulesNode = node.get("schedules");
     if (!schedulesNode.isArray()) {
       throw new IllegalArgumentException("Schedules node is not an array: " + schedulesNode);
     }
@@ -948,10 +930,10 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     try {
       return Optional.of(
           new ScheduleSignature(
-              parseTimestamp(node.get(CONSENSUS_TIMESTAMP).asText()),
-              node.get(PUBLIC_KEY_PREFIX).asText(),
-              node.get(SIGNATURE).asText(),
-              node.get(TYPE).asText()));
+              parseTimestamp(node.get("consensus_timestamp").asText()),
+              node.get("public_key_prefix").asText(),
+              node.get("signature").asText(),
+              node.get("type").asText()));
     } catch (final Exception e) {
       throw new JsonParseException(node, e);
     }
@@ -973,7 +955,7 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     if (field == null || field.isNull()) {
       return null;
     }
-    return PublicKey.fromString(field.get(KEY).asText());
+    return PublicKey.fromString(field.get("key").asText());
   }
 
   private AccountId accountIdOrNull(@NonNull JsonNode node, @NonNull String fieldName) {

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
@@ -58,6 +58,24 @@ import org.jspecify.annotations.NonNull;
 
 public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<JsonNode> {
 
+  private static final String ADMIN_KEY = "admin_key";
+  private static final String CONSENSUS_TIMESTAMP = "consensus_timestamp";
+  private static final String CREATOR_ACCOUNT_ID = "creator_account_id";
+  private static final String DELETED = "deleted";
+  private static final String EXECUTED_TIMESTAMP = "executed_timestamp";
+  private static final String EXPIRATION_TIME = "expiration_time";
+  private static final String KEY = "key";
+  private static final String MEMO = "memo";
+  private static final String PAYER_ACCOUNT_ID = "payer_account_id";
+  private static final String PUBLIC_KEY_PREFIX = "public_key_prefix";
+  private static final String SCHEDULE_ID = "schedule_id";
+  private static final String SCHEDULES = "schedules";
+  private static final String SIGNATURE = "signature";
+  private static final String SIGNATURES = "signatures";
+  private static final String TRANSACTION_BODY = "transaction_body";
+  private static final String TYPE = "type";
+  private static final String WAIT_FOR_EXPIRY = "wait_for_expiry";
+
   @Override
   public Optional<Nft> toNft(final JsonNode node) {
     Objects.requireNonNull(node, "jsonNode must not be null");
@@ -869,23 +887,23 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
 
     try {
       final byte[] transactionBody =
-          node.get("transaction_body").isNull()
+          node.get(TRANSACTION_BODY).isNull()
               ? null
-              : Base64.getDecoder().decode(node.get("transaction_body").asText());
+              : Base64.getDecoder().decode(node.get(TRANSACTION_BODY).asText());
       return Optional.of(
           new Schedule(
-              ScheduleId.fromString(node.get("schedule_id").asText()),
-              publicKeyOrNull(node, "admin_key"),
-              node.get("deleted").asBoolean(),
-              parseTimestamp(node.get("consensus_timestamp").asText()),
-              AccountId.fromString(node.get("creator_account_id").asText()),
-              timestampOrNull(node, "executed_timestamp"),
-              timestampOrNull(node, "expiration_time"),
-              node.get("memo").asText(),
-              accountIdOrNull(node, "payer_account_id"),
-              scheduleSignatures(node.get("signatures")),
+              ScheduleId.fromString(node.get(SCHEDULE_ID).asText()),
+              publicKeyOrNull(node, ADMIN_KEY),
+              node.get(DELETED).asBoolean(),
+              parseTimestamp(node.get(CONSENSUS_TIMESTAMP).asText()),
+              AccountId.fromString(node.get(CREATOR_ACCOUNT_ID).asText()),
+              timestampOrNull(node, EXECUTED_TIMESTAMP),
+              timestampOrNull(node, EXPIRATION_TIME),
+              node.get(MEMO).asText(),
+              accountIdOrNull(node, PAYER_ACCOUNT_ID),
+              scheduleSignatures(node.get(SIGNATURES)),
               transactionBody,
-              node.get("wait_for_expiry").asBoolean()));
+              node.get(WAIT_FOR_EXPIRY).asBoolean()));
     } catch (final Exception e) {
       throw new JsonParseException(node, e);
     }
@@ -908,10 +926,10 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
   @Override
   public @NonNull List<Schedule> toSchedules(@NonNull JsonNode node) {
     Objects.requireNonNull(node, "jsonNode must not be null");
-    if (!node.has("schedules")) {
+    if (!node.has(SCHEDULES)) {
       return List.of();
     }
-    final JsonNode schedulesNode = node.get("schedules");
+    final JsonNode schedulesNode = node.get(SCHEDULES);
     if (!schedulesNode.isArray()) {
       throw new IllegalArgumentException("Schedules node is not an array: " + schedulesNode);
     }
@@ -930,10 +948,10 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     try {
       return Optional.of(
           new ScheduleSignature(
-              parseTimestamp(node.get("consensus_timestamp").asText()),
-              node.get("public_key_prefix").asText(),
-              node.get("signature").asText(),
-              node.get("type").asText()));
+              parseTimestamp(node.get(CONSENSUS_TIMESTAMP).asText()),
+              node.get(PUBLIC_KEY_PREFIX).asText(),
+              node.get(SIGNATURE).asText(),
+              node.get(TYPE).asText()));
     } catch (final Exception e) {
       throw new JsonParseException(node, e);
     }
@@ -955,7 +973,7 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     if (field == null || field.isNull()) {
       return null;
     }
-    return PublicKey.fromString(field.get("key").asText());
+    return PublicKey.fromString(field.get(KEY).asText());
   }
 
   private AccountId accountIdOrNull(@NonNull JsonNode node, @NonNull String fieldName) {

--- a/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/MirrorNodeJsonConverterImplScheduleTest.java
+++ b/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/MirrorNodeJsonConverterImplScheduleTest.java
@@ -1,0 +1,111 @@
+package org.hiero.spring.test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.ScheduleId;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import org.hiero.base.data.Schedule;
+import org.hiero.spring.implementation.MirrorNodeJsonConverterImpl;
+import org.junit.jupiter.api.Test;
+
+class MirrorNodeJsonConverterImplScheduleTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final MirrorNodeJsonConverterImpl converter = new MirrorNodeJsonConverterImpl();
+
+  @Test
+  void toSchedulesReturnsEmptyWhenKeyMissing() throws Exception {
+    final JsonNode jsonNode = objectMapper.readTree("{\"links\":{\"next\":null}}");
+
+    final List<Schedule> result = converter.toSchedules(jsonNode);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void toSchedulesParsesSingleEntry() throws Exception {
+    final JsonNode jsonNode = objectMapper.readTree(schedulesJson());
+
+    final List<Schedule> result = converter.toSchedules(jsonNode);
+
+    assertEquals(1, result.size());
+    assertSchedule(result.get(0));
+  }
+
+  @Test
+  void toScheduleParsesSingleEntry() throws Exception {
+    final JsonNode jsonNode = objectMapper.readTree(scheduleJson());
+
+    final Schedule schedule = converter.toSchedule(jsonNode).orElseThrow();
+
+    assertSchedule(schedule);
+  }
+
+  private static void assertSchedule(final Schedule schedule) {
+    assertEquals(ScheduleId.fromString("0.0.7007"), schedule.scheduleId());
+    assertNull(schedule.adminKey());
+    assertFalse(schedule.deleted());
+    assertEquals(Instant.ofEpochSecond(1_586_567_700L, 453_054_000), schedule.consensusTimestamp());
+    assertEquals(AccountId.fromString("0.0.1001"), schedule.creatorAccountId());
+    assertNull(schedule.executedTimestamp());
+    assertEquals(Instant.ofEpochSecond(1_586_567_800L, 1), schedule.expirationTime());
+    assertEquals("scheduled transfer", schedule.memo());
+    assertEquals(AccountId.fromString("0.0.1002"), schedule.payerAccountId());
+    assertArrayEquals("test-body".getBytes(StandardCharsets.UTF_8), schedule.transactionBody());
+    assertFalse(schedule.waitForExpiry());
+    assertEquals(1, schedule.signatures().size());
+    assertEquals(
+        Instant.ofEpochSecond(1_586_567_710L, 111_222_333),
+        schedule.signatures().get(0).consensusTimestamp());
+    assertEquals("0x0102", schedule.signatures().get(0).publicKeyPrefix());
+    assertEquals("0x0304", schedule.signatures().get(0).signature());
+    assertEquals("ED25519", schedule.signatures().get(0).type());
+  }
+
+  private static String schedulesJson() {
+    return """
+        {
+          "schedules": [
+            %s
+          ],
+          "links": {"next": null}
+        }
+        """
+        .formatted(scheduleJson());
+  }
+
+  private static String scheduleJson() {
+    return """
+        {
+          "admin_key": null,
+          "deleted": false,
+          "consensus_timestamp": "1586567700.453054000",
+          "creator_account_id": "0.0.1001",
+          "executed_timestamp": null,
+          "expiration_time": "1586567800.000000001",
+          "memo": "scheduled transfer",
+          "payer_account_id": "0.0.1002",
+          "schedule_id": "0.0.7007",
+          "signatures": [
+            {
+              "consensus_timestamp": "1586567710.111222333",
+              "public_key_prefix": "0x0102",
+              "signature": "0x0304",
+              "type": "ED25519"
+            }
+          ],
+          "transaction_body": "dGVzdC1ib2R5",
+          "wait_for_expiry": false
+        }
+        """;
+  }
+}

--- a/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/ScheduleRepositoryTest.java
+++ b/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/ScheduleRepositoryTest.java
@@ -1,9 +1,18 @@
 package org.hiero.spring.test;
 
 import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.ScheduleCreateTransaction;
 import com.hedera.hashgraph.sdk.ScheduleId;
+import com.hedera.hashgraph.sdk.TransactionReceipt;
+import com.hedera.hashgraph.sdk.TransferTransaction;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
+import org.hiero.base.AccountClient;
+import org.hiero.base.HieroContext;
 import org.hiero.base.HieroException;
+import org.hiero.base.data.Account;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.Schedule;
 import org.hiero.base.mirrornode.ScheduleRepository;
@@ -15,7 +24,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(classes = HieroTestConfig.class)
 public class ScheduleRepositoryTest {
 
+  private static final String E2E_SCHEDULE_MEMO = "hiero schedule repository e2e";
+  private static final Duration MIRROR_NODE_TIMEOUT = Duration.ofSeconds(30);
+
   @Autowired private ScheduleRepository scheduleRepository;
+
+  @Autowired private AccountClient accountClient;
+
+  @Autowired private HieroContext hieroContext;
 
   @Test
   void testNullParam() {
@@ -51,5 +67,53 @@ public class ScheduleRepositoryTest {
 
     Assertions.assertNotNull(result);
     Assertions.assertTrue(result.getData().isEmpty());
+  }
+
+  @Test
+  void testFindCreatedScheduleByIdAndAccountId() throws Exception {
+    final Account signerAccount = accountClient.createAccount(Hbar.fromTinybars(1_000_000));
+    final AccountId operatorAccountId = hieroContext.getOperatorAccount().accountId();
+    final ScheduleId scheduleId =
+        createPendingSchedule(signerAccount.accountId(), operatorAccountId);
+
+    final Schedule schedule = waitForSchedule(scheduleId);
+    final Page<Schedule> schedules = scheduleRepository.findByAccountId(operatorAccountId);
+
+    Assertions.assertEquals(scheduleId, schedule.scheduleId());
+    Assertions.assertEquals(operatorAccountId, schedule.creatorAccountId());
+    Assertions.assertEquals(E2E_SCHEDULE_MEMO, schedule.memo());
+    Assertions.assertTrue(
+        schedules.getData().stream().anyMatch(s -> scheduleId.equals(s.scheduleId())));
+  }
+
+  private ScheduleId createPendingSchedule(
+      final AccountId signerAccountId, final AccountId operatorAccountId) throws Exception {
+    final TransactionReceipt receipt =
+        new ScheduleCreateTransaction()
+            .setScheduleMemo(E2E_SCHEDULE_MEMO)
+            .setAdminKey(hieroContext.getOperatorAccount().publicKey())
+            .setScheduledTransaction(
+                new TransferTransaction()
+                    .addHbarTransfer(signerAccountId, Hbar.fromTinybars(-1))
+                    .addHbarTransfer(operatorAccountId, Hbar.fromTinybars(1)))
+            .execute(hieroContext.getClient())
+            .getReceipt(hieroContext.getClient());
+    Assertions.assertNotNull(receipt.scheduleId);
+    return receipt.scheduleId;
+  }
+
+  private Schedule waitForSchedule(final ScheduleId scheduleId) throws HieroException {
+    final Instant deadline = Instant.now().plus(MIRROR_NODE_TIMEOUT);
+    Optional<Schedule> schedule = scheduleRepository.findById(scheduleId);
+    while (schedule.isEmpty() && Instant.now().isBefore(deadline)) {
+      try {
+        Thread.sleep(500);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Interrupted while waiting for schedule", e);
+      }
+      schedule = scheduleRepository.findById(scheduleId);
+    }
+    return schedule.orElseThrow(() -> new AssertionError("Schedule not found: " + scheduleId));
   }
 }

--- a/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/ScheduleRepositoryTest.java
+++ b/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/ScheduleRepositoryTest.java
@@ -1,0 +1,55 @@
+package org.hiero.spring.test;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.ScheduleId;
+import java.util.Optional;
+import org.hiero.base.HieroException;
+import org.hiero.base.data.Page;
+import org.hiero.base.data.Schedule;
+import org.hiero.base.mirrornode.ScheduleRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = HieroTestConfig.class)
+public class ScheduleRepositoryTest {
+
+  @Autowired private ScheduleRepository scheduleRepository;
+
+  @Test
+  void testNullParam() {
+    Assertions.assertThrows(
+        NullPointerException.class, () -> scheduleRepository.findById((String) null));
+    Assertions.assertThrows(
+        NullPointerException.class, () -> scheduleRepository.findByAccountId((String) null));
+  }
+
+  @Test
+  void testFindAll() throws HieroException {
+    final Page<Schedule> result = scheduleRepository.findAll();
+
+    Assertions.assertNotNull(result);
+    Assertions.assertNotNull(result.getData());
+  }
+
+  @Test
+  void testFindByIdReturnsEmptyOptionalForInvalidId() throws HieroException {
+    final ScheduleId scheduleId = ScheduleId.fromString("1.2.3");
+
+    final Optional<Schedule> result = scheduleRepository.findById(scheduleId);
+
+    Assertions.assertNotNull(result);
+    Assertions.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testFindByAccountIdReturnsEmptyListForAccountWithoutSchedules() throws HieroException {
+    final AccountId accountId = AccountId.fromString("1.2.3");
+
+    final Page<Schedule> result = scheduleRepository.findByAccountId(accountId);
+
+    Assertions.assertNotNull(result);
+    Assertions.assertTrue(result.getData().isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

Adds Mirror Node support for schedules through a new `ScheduleRepository`, matching the repository pattern already used for other mirror-node resources.

This includes:
- querying schedules as a paged list
- querying schedules by `account.id`
- fetching a single schedule by `ScheduleId`
- parsing schedule detail/list responses, signatures, timestamps, and Base64 `transaction_body`
- wiring the repository in both Spring and MicroProfile modules

## Why

Mirror Node exposes scheduled transactions under `/api/v1/schedules`, but this library did not provide a first-class way to access them. This change adds that support without requiring callers to build their own REST requests or JSON parsing.

## Implementation Notes

- Adds `Schedule` and `ScheduleSignature` data records in `hiero-enterprise-base`.
- Adds `ScheduleRepository` and `ScheduleRepositoryImpl`.
- Extends `MirrorNodeClient` with schedule list, account-filtered list, and id lookup methods.
- Implements schedule REST calls and JSON conversion for Spring and MicroProfile.
- Uses constants for schedule REST paths and JSON field names.

## Testing

Added focused schedule JSON converter tests for both Spring and MicroProfile covering:
- list responses wrapped in `schedules`
- single schedule responses
- signatures
- timestamp fields
- Base64 `transaction_body` decoding

Local validation:
- focused schedule converter tests pass
- `spotless:check` passes