### PR TITLE
test: remove duplicate executeTokenCreateTransaction(null) assertion

### DIFF
--- a/hiero-enterprise-base/src/test/java/org/hiero/base/test/ProtocolLayerClientTests.java
+++ b/hiero-enterprise-base/src/test/java/org/hiero/base/test/ProtocolLayerClientTests.java
@@ -72,8 +72,6 @@ public class ProtocolLayerClientTests {
     Assertions.assertThrows(
         NullPointerException.class, () -> client.executeTopicMessageSubmitTransaction(null));
     Assertions.assertThrows(
-        NullPointerException.class, () -> client.executeTokenCreateTransaction(null));
-    Assertions.assertThrows(
         NullPointerException.class, () -> client.executeBurnTokenTransaction(null));
     Assertions.assertThrows(
         NullPointerException.class, () -> client.executeMintTokenTransaction(null));


### PR DESCRIPTION
Drop redundant duplicate of `executeTokenCreateTransaction(null)` in `ProtocolLayerClientTests`; behavior unchanged.