### PR TITLE
feat(microprofile): expose TopicClient and TopicRepository as CDI beans

### DIFF
--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
@@ -11,6 +11,7 @@ import org.hiero.base.HieroContext;
 import org.hiero.base.HookClient;
 import org.hiero.base.NftClient;
 import org.hiero.base.SmartContractClient;
+import org.hiero.base.TopicClient;
 import org.hiero.base.config.HieroConfig;
 import org.hiero.base.implementation.AccountClientImpl;
 import org.hiero.base.implementation.AccountRepositoryImpl;
@@ -25,6 +26,8 @@ import org.hiero.base.implementation.NftRepositoryImpl;
 import org.hiero.base.implementation.ProtocolLayerClientImpl;
 import org.hiero.base.implementation.SmartContractClientImpl;
 import org.hiero.base.implementation.TokenRepositoryImpl;
+import org.hiero.base.implementation.TopicClientImpl;
+import org.hiero.base.implementation.TopicRepositoryImpl;
 import org.hiero.base.implementation.TransactionRepositoryImpl;
 import org.hiero.base.mirrornode.AccountRepository;
 import org.hiero.base.mirrornode.BlockRepository;
@@ -33,6 +36,7 @@ import org.hiero.base.mirrornode.MirrorNodeClient;
 import org.hiero.base.mirrornode.NetworkRepository;
 import org.hiero.base.mirrornode.NftRepository;
 import org.hiero.base.mirrornode.TokenRepository;
+import org.hiero.base.mirrornode.TopicRepository;
 import org.hiero.base.mirrornode.TransactionRepository;
 import org.hiero.base.protocol.ProtocolLayerClient;
 import org.hiero.base.verification.ContractVerificationClient;
@@ -114,6 +118,15 @@ public class ClientProvider {
   @NonNull
   @Produces
   @ApplicationScoped
+  TopicClient createTopicClient(
+      @NonNull final ProtocolLayerClient protocolLayerClient,
+      @NonNull final HieroContext hieroContext) {
+    return new TopicClientImpl(protocolLayerClient, hieroContext.getOperatorAccount());
+  }
+
+  @NonNull
+  @Produces
+  @ApplicationScoped
   HookClient createHookClient(@NonNull final ProtocolLayerClient protocolLayerClient) {
     return new HookClientImpl(protocolLayerClient);
   }
@@ -187,5 +200,12 @@ public class ClientProvider {
   @ApplicationScoped
   ContractRepository createContractRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
     return new ContractRepositoryImpl(mirrorNodeClient);
+  }
+
+  @NonNull
+  @Produces
+  @ApplicationScoped
+  TopicRepository createTopicRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
+    return new TopicRepositoryImpl(mirrorNodeClient);
   }
 }


### PR DESCRIPTION
## Desciption
This PR resolves an inconsistency between the Spring and MicroProfile modules by exposing TopicClient and TopicRepository as CDI beans. Previously, these were missing from ClientProvider.java, causing injection failures in MicroProfile/Quarkus environments.

## Key Changes:

1. Added @Produces methods for TopicClient and TopicRepository in ClientProvider.java.
2. Aligned MicroProfile client availability with the existing Spring module configuration.
3. Ensured proper dependency injection support for all core Hedera clients.

## Verification:

Successfully compiled via ``` ./mvnw clean compile -pl hiero-enterprise-microprofile -am ```

This PR resolves issue #63. Please let me know if any further changes are required.