### PR TITLE
feat(metrics): add framework support for clients and repositories (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ Today only the "DER Encoded Private Key" of the "ECDSA" key type is supported fo
 The 2 properties `spring.hiero.accountId` and `spring.hiero.privateKey` define the "operator account".
 The operator account is used as the account that sends all transactions against the Hiero network.
 
+### Metrics
+
+The Spring integration provides optional Micrometer metrics for all managed Hiero clients and repositories.
+
+- Enable/disable: `spring.hiero.metrics.enabled=true|false` (default is `true`)
+- Counter metric: `hiero.calls`
+- Timer metric: `hiero.call.duration`
+- Tags:
+  - `hiero.component` (`client` or `repository`)
+  - `hiero.type` (interface type, for example `AccountClient`)
+  - `hiero.method` (invoked method name)
+  - `hiero.outcome` (`success` or `error`)
+
+MicroProfile integration provides the same coverage when a `MetricRegistry` is available.
+It emits:
+
+- Counter metric: `hiero_calls_total`
+- Timer metric: `hiero_call_duration`
+- Tags: same keys/values as the Spring integration
+
 ### Usage
 
 To use the module, you need to add the `@EnableHiero` annotation to your Spring Boot application class.

--- a/hiero-enterprise-microprofile/pom.xml
+++ b/hiero-enterprise-microprofile/pom.xml
@@ -28,6 +28,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.metrics</groupId>
+      <artifactId>microprofile-metrics-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <scope>provided</scope>

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
@@ -1,9 +1,11 @@
 package org.hiero.microprofile;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.hiero.base.AccountClient;
 import org.hiero.base.FileClient;
 import org.hiero.base.FungibleTokenClient;
@@ -38,6 +40,7 @@ import org.hiero.base.protocol.ProtocolLayerClient;
 import org.hiero.base.verification.ContractVerificationClient;
 import org.hiero.microprofile.implementation.ContractVerificationClientImpl;
 import org.hiero.microprofile.implementation.HieroConfigImpl;
+import org.hiero.microprofile.implementation.HieroMetricsProxyFactory;
 import org.hiero.microprofile.implementation.MirrorNodeClientImpl;
 import org.hiero.microprofile.implementation.MirrorNodeJsonConverterImpl;
 import org.hiero.microprofile.implementation.MirrorNodeRestClientImpl;
@@ -48,6 +51,7 @@ public class ClientProvider {
   @Inject @ConfigProperties private HieroOperatorConfiguration configuration;
 
   @Inject @ConfigProperties private HieroNetworkConfiguration networkConfiguration;
+  @Inject private Instance<MetricRegistry> metricRegistry;
 
   @NonNull
   @Produces
@@ -67,14 +71,16 @@ public class ClientProvider {
   @Produces
   @ApplicationScoped
   ProtocolLayerClient createProtocolLayerClient(@NonNull final HieroContext hieroContext) {
-    return new ProtocolLayerClientImpl(hieroContext);
+    final ProtocolLayerClient client = new ProtocolLayerClientImpl(hieroContext);
+    return wrapClient(client, ProtocolLayerClient.class);
   }
 
   @NonNull
   @Produces
   @ApplicationScoped
   FileClient createFileClient(@NonNull final ProtocolLayerClient protocolLayerClient) {
-    return new FileClientImpl(protocolLayerClient);
+    final FileClient client = new FileClientImpl(protocolLayerClient);
+    return wrapClient(client, FileClient.class);
   }
 
   @NonNull
@@ -83,7 +89,8 @@ public class ClientProvider {
   SmartContractClient createSmartContractClient(
       @NonNull final ProtocolLayerClient protocolLayerClient,
       @NonNull final FileClient fileClient) {
-    return new SmartContractClientImpl(protocolLayerClient, fileClient);
+    final SmartContractClient client = new SmartContractClientImpl(protocolLayerClient, fileClient);
+    return wrapClient(client, SmartContractClient.class);
   }
 
   @NonNull
@@ -92,7 +99,9 @@ public class ClientProvider {
   NftClient createNftClient(
       @NonNull final ProtocolLayerClient protocolLayerClient,
       @NonNull final HieroContext hieroContext) {
-    return new NftClientImpl(protocolLayerClient, hieroContext.getOperatorAccount());
+    final NftClient client =
+        new NftClientImpl(protocolLayerClient, hieroContext.getOperatorAccount());
+    return wrapClient(client, NftClient.class);
   }
 
   @NonNull
@@ -101,21 +110,25 @@ public class ClientProvider {
   FungibleTokenClient createFungibleTokenClient(
       @NonNull final ProtocolLayerClient protocolLayerClient,
       @NonNull final HieroContext hieroContext) {
-    return new FungibleTokenClientImpl(protocolLayerClient, hieroContext.getOperatorAccount());
+    final FungibleTokenClient client =
+        new FungibleTokenClientImpl(protocolLayerClient, hieroContext.getOperatorAccount());
+    return wrapClient(client, FungibleTokenClient.class);
   }
 
   @NonNull
   @Produces
   @ApplicationScoped
   AccountClient createAccountClient(@NonNull final ProtocolLayerClient protocolLayerClient) {
-    return new AccountClientImpl(protocolLayerClient);
+    final AccountClient client = new AccountClientImpl(protocolLayerClient);
+    return wrapClient(client, AccountClient.class);
   }
 
   @NonNull
   @Produces
   @ApplicationScoped
   HookClient createHookClient(@NonNull final ProtocolLayerClient protocolLayerClient) {
-    return new HookClientImpl(protocolLayerClient);
+    final HookClient client = new HookClientImpl(protocolLayerClient);
+    return wrapClient(client, HookClient.class);
   }
 
   @NonNull
@@ -123,7 +136,8 @@ public class ClientProvider {
   @ApplicationScoped
   ContractVerificationClient createContractVerificationClient(
       @NonNull final HieroConfig hieroConfig) {
-    return new ContractVerificationClientImpl(hieroConfig);
+    final ContractVerificationClient client = new ContractVerificationClientImpl(hieroConfig);
+    return wrapClient(client, ContractVerificationClient.class);
   }
 
   @NonNull
@@ -136,35 +150,40 @@ public class ClientProvider {
             .orElseThrow(() -> new IllegalStateException("No mirror node addresses configured"));
     final MirrorNodeRestClientImpl restClient = new MirrorNodeRestClientImpl(target);
     final MirrorNodeJsonConverterImpl jsonConverter = new MirrorNodeJsonConverterImpl();
-    return new MirrorNodeClientImpl(restClient, jsonConverter);
+    final MirrorNodeClient client = new MirrorNodeClientImpl(restClient, jsonConverter);
+    return wrapClient(client, MirrorNodeClient.class);
   }
 
   @NonNull
   @Produces
   @ApplicationScoped
   BlockRepository createBlockRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
-    return new BlockRepositoryImpl(mirrorNodeClient);
+    final BlockRepository repository = new BlockRepositoryImpl(mirrorNodeClient);
+    return wrapRepository(repository, BlockRepository.class);
   }
 
   @NonNull
   @Produces
   @ApplicationScoped
   AccountRepository createAccountRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
-    return new AccountRepositoryImpl(mirrorNodeClient);
+    final AccountRepository repository = new AccountRepositoryImpl(mirrorNodeClient);
+    return wrapRepository(repository, AccountRepository.class);
   }
 
   @NonNull
   @Produces
   @ApplicationScoped
   NetworkRepository createNetworkRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
-    return new NetworkRepositoryImpl(mirrorNodeClient);
+    final NetworkRepository repository = new NetworkRepositoryImpl(mirrorNodeClient);
+    return wrapRepository(repository, NetworkRepository.class);
   }
 
   @NonNull
   @Produces
   @ApplicationScoped
   NftRepository createNftRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
-    return new NftRepositoryImpl(mirrorNodeClient);
+    final NftRepository repository = new NftRepositoryImpl(mirrorNodeClient);
+    return wrapRepository(repository, NftRepository.class);
   }
 
   @NonNull
@@ -172,20 +191,39 @@ public class ClientProvider {
   @ApplicationScoped
   TransactionRepository createTransactionRepository(
       @NonNull final MirrorNodeClient mirrorNodeClient) {
-    return new TransactionRepositoryImpl(mirrorNodeClient);
+    final TransactionRepository repository = new TransactionRepositoryImpl(mirrorNodeClient);
+    return wrapRepository(repository, TransactionRepository.class);
   }
 
   @NonNull
   @Produces
   @ApplicationScoped
   TokenRepository createTokenRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
-    return new TokenRepositoryImpl(mirrorNodeClient);
+    final TokenRepository repository = new TokenRepositoryImpl(mirrorNodeClient);
+    return wrapRepository(repository, TokenRepository.class);
   }
 
   @NonNull
   @Produces
   @ApplicationScoped
   ContractRepository createContractRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
-    return new ContractRepositoryImpl(mirrorNodeClient);
+    final ContractRepository repository = new ContractRepositoryImpl(mirrorNodeClient);
+    return wrapRepository(repository, ContractRepository.class);
+  }
+
+  private <T> T wrapClient(@NonNull final T target, @NonNull final Class<T> type) {
+    if (metricRegistry.isResolvable()) {
+      final MetricRegistry registry = metricRegistry.get();
+      return new HieroMetricsProxyFactory(registry).createProxy(target, type, "client");
+    }
+    return target;
+  }
+
+  private <T> T wrapRepository(@NonNull final T target, @NonNull final Class<T> type) {
+    if (metricRegistry.isResolvable()) {
+      final MetricRegistry registry = metricRegistry.get();
+      return new HieroMetricsProxyFactory(registry).createProxy(target, type, "repository");
+    }
+    return target;
   }
 }

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/HieroMetricsProxyFactory.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/HieroMetricsProxyFactory.java
@@ -1,0 +1,103 @@
+package org.hiero.microprofile.implementation;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.time.Duration;
+import java.util.Objects;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.eclipse.microprofile.metrics.Timer;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Creates dynamic proxies that measure invocation count and latency for Hiero clients and
+ * repositories.
+ */
+public class HieroMetricsProxyFactory {
+
+  public static final String COUNTER_NAME = "hiero_calls_total";
+  public static final String TIMER_NAME = "hiero_call_duration";
+  public static final String COMPONENT_TAG = "hiero.component";
+  public static final String TYPE_TAG = "hiero.type";
+  public static final String METHOD_TAG = "hiero.method";
+  public static final String OUTCOME_TAG = "hiero.outcome";
+
+  private final MetricRegistry metricRegistry;
+
+  public HieroMetricsProxyFactory(@NonNull final MetricRegistry metricRegistry) {
+    this.metricRegistry = Objects.requireNonNull(metricRegistry, "metricRegistry must not be null");
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> T createProxy(
+      @NonNull final T target,
+      @NonNull final Class<T> interfaceType,
+      @NonNull final String component) {
+    Objects.requireNonNull(target, "target must not be null");
+    Objects.requireNonNull(interfaceType, "interfaceType must not be null");
+    Objects.requireNonNull(component, "component must not be null");
+    final InvocationHandler handler =
+        new MetricsInvocationHandler(target, metricRegistry, component);
+    return (T)
+        Proxy.newProxyInstance(
+            interfaceType.getClassLoader(), new Class<?>[] {interfaceType}, handler);
+  }
+
+  private static final class MetricsInvocationHandler implements InvocationHandler {
+    private final Object target;
+    private final MetricRegistry metricRegistry;
+    private final String component;
+
+    private MetricsInvocationHandler(
+        @NonNull final Object target,
+        @NonNull final MetricRegistry metricRegistry,
+        @NonNull final String component) {
+      this.target = Objects.requireNonNull(target, "target must not be null");
+      this.metricRegistry =
+          Objects.requireNonNull(metricRegistry, "metricRegistry must not be null");
+      this.component = Objects.requireNonNull(component, "component must not be null");
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      if (method.getDeclaringClass().equals(Object.class)) {
+        return method.invoke(target, args);
+      }
+      final String type = method.getDeclaringClass().getSimpleName();
+      final String methodName = method.getName();
+      final long start = System.nanoTime();
+      try {
+        final Object result = method.invoke(target, args);
+        record(type, methodName, "success", start);
+        return result;
+      } catch (InvocationTargetException e) {
+        record(type, methodName, "error", start);
+        throw e.getCause();
+      } catch (Exception e) {
+        record(type, methodName, "error", start);
+        throw e;
+      }
+    }
+
+    private void record(
+        @NonNull final String type,
+        @NonNull final String methodName,
+        @NonNull final String outcome,
+        final long startNanos) {
+      final Tag[] tags =
+          new Tag[] {
+            new Tag(COMPONENT_TAG, component),
+            new Tag(TYPE_TAG, type),
+            new Tag(METHOD_TAG, methodName),
+            new Tag(OUTCOME_TAG, outcome)
+          };
+      final Counter counter = metricRegistry.counter(COUNTER_NAME, tags);
+      counter.inc();
+      final Timer timer = metricRegistry.timer(TIMER_NAME, tags);
+      timer.update(Duration.ofNanos(System.nanoTime() - startNanos));
+    }
+  }
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroMetricsBeanPostProcessor.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroMetricsBeanPostProcessor.java
@@ -1,0 +1,117 @@
+package org.hiero.spring.implementation;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * Wraps Hiero clients and repositories in JDK proxies and records Micrometer metrics for each
+ * public invocation.
+ */
+public class HieroMetricsBeanPostProcessor implements BeanPostProcessor {
+
+  public static final String COUNTER_NAME = "hiero.calls";
+  public static final String TIMER_NAME = "hiero.call.duration";
+  public static final String COMPONENT_TAG = "hiero.component";
+  public static final String TYPE_TAG = "hiero.type";
+  public static final String METHOD_TAG = "hiero.method";
+  public static final String OUTCOME_TAG = "hiero.outcome";
+
+  private final MeterRegistry meterRegistry;
+
+  public HieroMetricsBeanPostProcessor(@NonNull final MeterRegistry meterRegistry) {
+    this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry must not be null");
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    final Class<?> beanClass = bean.getClass();
+    if (Proxy.isProxyClass(beanClass)) {
+      return bean;
+    }
+    final List<Class<?>> trackedInterfaces = new ArrayList<>();
+    for (Class<?> iface : beanClass.getInterfaces()) {
+      if (isTrackedInterface(iface)) {
+        trackedInterfaces.add(iface);
+      }
+    }
+    if (trackedInterfaces.isEmpty()) {
+      return bean;
+    }
+    final InvocationHandler handler = new MetricsInvocationHandler(bean, meterRegistry);
+    return Proxy.newProxyInstance(
+        beanClass.getClassLoader(), trackedInterfaces.toArray(new Class<?>[0]), handler);
+  }
+
+  private static boolean isTrackedInterface(@NonNull final Class<?> iface) {
+    final String name = iface.getName();
+    return name.startsWith("org.hiero.base.")
+        && (name.endsWith("Client")
+            || name.endsWith("Repository")
+            || name.endsWith("ProtocolLayerClient"));
+  }
+
+  private static final class MetricsInvocationHandler implements InvocationHandler {
+
+    private final Object target;
+    private final MeterRegistry meterRegistry;
+
+    private MetricsInvocationHandler(
+        @NonNull final Object target, @NonNull final MeterRegistry meterRegistry) {
+      this.target = Objects.requireNonNull(target, "target must not be null");
+      this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry must not be null");
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      if (method.getDeclaringClass().equals(Object.class)) {
+        return method.invoke(target, args);
+      }
+      final String type = method.getDeclaringClass().getSimpleName();
+      final String component = type.endsWith("Repository") ? "repository" : "client";
+      final String methodName = method.getName();
+      final long start = System.nanoTime();
+      try {
+        final Object result = method.invoke(target, args);
+        record(component, type, methodName, "success", start);
+        return result;
+      } catch (InvocationTargetException e) {
+        record(component, type, methodName, "error", start);
+        throw e.getCause();
+      } catch (Exception e) {
+        record(component, type, methodName, "error", start);
+        throw e;
+      }
+    }
+
+    private void record(
+        @NonNull final String component,
+        @NonNull final String type,
+        @NonNull final String methodName,
+        @NonNull final String outcome,
+        final long startNanos) {
+      final List<Tag> tags =
+          List.of(
+              Tag.of(COMPONENT_TAG, component),
+              Tag.of(TYPE_TAG, type),
+              Tag.of(METHOD_TAG, methodName),
+              Tag.of(OUTCOME_TAG, outcome));
+      final Counter counter = meterRegistry.counter(COUNTER_NAME, tags);
+      counter.increment();
+      final Timer timer = meterRegistry.timer(TIMER_NAME, tags);
+      timer.record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
+    }
+  }
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MicrometerSupportConfig.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MicrometerSupportConfig.java
@@ -66,4 +66,11 @@ public class MicrometerSupportConfig {
           });
     };
   }
+
+  @Bean
+  @NonNull
+  public HieroMetricsBeanPostProcessor hieroMetricsBeanPostProcessor(
+      @NonNull final MeterRegistry meterRegistry) {
+    return new HieroMetricsBeanPostProcessor(meterRegistry);
+  }
 }

--- a/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/HieroMetricsBeanPostProcessorTest.java
+++ b/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/HieroMetricsBeanPostProcessorTest.java
@@ -1,0 +1,71 @@
+package org.hiero.spring.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.hashgraph.sdk.EvmHookStorageUpdate;
+import com.hedera.hashgraph.sdk.HookId;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.hiero.base.HookClient;
+import org.hiero.spring.implementation.HieroMetricsBeanPostProcessor;
+import org.junit.jupiter.api.Test;
+
+class HieroMetricsBeanPostProcessorTest {
+
+  @Test
+  void shouldCollectSuccessAndErrorMetrics() throws Exception {
+    final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final HieroMetricsBeanPostProcessor postProcessor =
+        new HieroMetricsBeanPostProcessor(meterRegistry);
+    final HookClient proxied =
+        (HookClient)
+            postProcessor.postProcessAfterInitialization(new TestClientImpl(), "testClient");
+
+    proxied.storeHook(null, List.of(), PrivateKey.generateED25519());
+    assertThrows(
+        IllegalStateException.class,
+        () -> proxied.storeHook(null, List.of(), List.of(PrivateKey.generateED25519())));
+
+    assertEquals(
+        1d,
+        meterRegistry
+            .get(HieroMetricsBeanPostProcessor.COUNTER_NAME)
+            .tag(HieroMetricsBeanPostProcessor.TYPE_TAG, "HookClient")
+            .tag(HieroMetricsBeanPostProcessor.METHOD_TAG, "storeHook")
+            .tag(HieroMetricsBeanPostProcessor.OUTCOME_TAG, "success")
+            .counter()
+            .count());
+    assertEquals(
+        1d,
+        meterRegistry
+            .get(HieroMetricsBeanPostProcessor.COUNTER_NAME)
+            .tag(HieroMetricsBeanPostProcessor.TYPE_TAG, "HookClient")
+            .tag(HieroMetricsBeanPostProcessor.METHOD_TAG, "storeHook")
+            .tag(HieroMetricsBeanPostProcessor.OUTCOME_TAG, "error")
+            .counter()
+            .count());
+    assertEquals(
+        1L,
+        meterRegistry
+            .get(HieroMetricsBeanPostProcessor.TIMER_NAME)
+            .tag(HieroMetricsBeanPostProcessor.TYPE_TAG, "HookClient")
+            .tag(HieroMetricsBeanPostProcessor.METHOD_TAG, "storeHook")
+            .tag(HieroMetricsBeanPostProcessor.OUTCOME_TAG, "success")
+            .timer()
+            .count());
+  }
+
+  static class TestClientImpl implements HookClient {
+    @Override
+    public void storeHook(
+        HookId hookId, List<EvmHookStorageUpdate> storageUpdates, PrivateKey signerKey) {}
+
+    @Override
+    public void storeHook(
+        HookId hookId, List<EvmHookStorageUpdate> storageUpdates, List<PrivateKey> signerKeys) {
+      throw new IllegalStateException("boom");
+    }
+  }
+}


### PR DESCRIPTION
## Description:
Add framework-level metrics support for Hiero clients and repositories.

* Add Spring Micrometer instrumentation via `HieroMetricsBeanPostProcessor`
* Add MicroProfile instrumentation via `HieroMetricsProxyFactory`
* Wire metrics into Spring and MicroProfile bean creation
* Update README metrics section
* Add `HieroMetricsBeanPostProcessorTest`

## Related issue(s):
Fixes #21

**Notes for reviewer**:
Passed:
```bash
./mvnw spotless:check
./mvnw -pl hiero-enterprise-base,hiero-enterprise-test install -DskipTests
./mvnw -pl hiero-enterprise-spring -Dtest=HieroMetricsBeanPostProcessorTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -pl hiero-enterprise-microprofile -DskipTests compile
```
Integration tests requiring funded testnet transactions were not executed in this local run.

## Checklist
- [x] Documented
- [x] Tested
