### PR TITLE
feat: add ReceiveRecordInterceptor to MicroProfile and implement UINT64 support

### DIFF
--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/data/BigIntegerBasedNumericDatatypes.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/data/BigIntegerBasedNumericDatatypes.java
@@ -128,6 +128,11 @@ public enum BigIntegerBasedNumericDatatypes implements ParamSupplier<BigInteger>
       BigInteger.valueOf(2).pow(255).negate(),
       BigInteger.valueOf(2).pow(255).subtract(BigInteger.ONE)),
 
+  UINT64(
+      "uint64",
+      (v, params) -> params.addUint64(v.longValue()),
+      BigInteger.ZERO,
+      BigInteger.valueOf(2).pow(64).subtract(BigInteger.ONE)),
   UINT72(
       "uint72",
       (v, params) -> params.addUint72(v),

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/data/LongBasedNumericDatatypes.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/data/LongBasedNumericDatatypes.java
@@ -20,7 +20,6 @@ public enum LongBasedNumericDatatypes implements ParamSupplier<Long> {
   INT56("int56", (v, params) -> params.addInt56(v), -72057594037927936L, 72057594037927935L),
   UINT56("uint56", (v, params) -> params.addUint56(v), 0L, 144115188075855871L),
   INT64("int64", (v, params) -> params.addInt64(v), Long.MIN_VALUE, Long.MAX_VALUE);
-  // TODO; UINT64 but max value is > long max value
 
   private final BiConsumer<Long, ContractFunctionParameters> addParam;
 

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
@@ -1,6 +1,7 @@
 package org.hiero.microprofile;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperties;
@@ -30,6 +31,7 @@ import org.hiero.base.mirrornode.NetworkRepository;
 import org.hiero.base.mirrornode.NftRepository;
 import org.hiero.base.mirrornode.TokenRepository;
 import org.hiero.base.mirrornode.TransactionRepository;
+import org.hiero.base.interceptors.ReceiveRecordInterceptor;
 import org.hiero.base.protocol.ProtocolLayerClient;
 import org.hiero.base.verification.ContractVerificationClient;
 import org.hiero.microprofile.implementation.ContractVerificationClientImpl;
@@ -44,6 +46,8 @@ public class ClientProvider {
   @Inject @ConfigProperties private HieroOperatorConfiguration configuration;
 
   @Inject @ConfigProperties private HieroNetworkConfiguration networkConfiguration;
+
+  @Inject private Instance<ReceiveRecordInterceptor> interceptors;
 
   @NonNull
   @Produces
@@ -63,7 +67,9 @@ public class ClientProvider {
   @Produces
   @ApplicationScoped
   ProtocolLayerClient createProtocolLayerClient(@NonNull final HieroContext hieroContext) {
-    return new ProtocolLayerClientImpl(hieroContext);
+    final ProtocolLayerClientImpl client = new ProtocolLayerClientImpl(hieroContext);
+    interceptors.stream().findFirst().ifPresent(client::setRecordInterceptor);
+    return client;
   }
 
   @NonNull


### PR DESCRIPTION
## Description
This PR addresses two issues identified in the MicroProfile module and the base numeric datatypes:
1. **ReceiveRecordInterceptor in MicroProfile**: Added support for optional injection of `ReceiveRecordInterceptor` in `ClientProvider.java`, matching the behavior in the Spring module. This enables consistent observability and metrics across frameworks.
2. **UINT64 Support**: Implemented `UINT64` support in `BigIntegerBasedNumericDatatypes.java` using `BigInteger` for range validation. The corresponding TODO in `LongBasedNumericDatatypes.java` has been removed.

## Changes
- **MicroProfile**: Injected `Instance<ReceiveRecordInterceptor>` in `ClientProvider` and applied it to `ProtocolLayerClient`.
- **Base**: Added `UINT64` to `BigIntegerBasedNumericDatatypes`.
- **Base**: Removed `UINT64` TODO from `LongBasedNumericDatatypes`.

## Verification
- Verified compilation of all modules with `./mvnw clean compile -DskipTests`.

This resolves issue #124. Looking forward to your feedback.