### PR TITLE
fix(base): expirationTime on large FileClient.createFile

### DIFF
--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/FileClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/FileClientImpl.java
@@ -73,7 +73,12 @@ public class FileClientImpl implements FileClient {
             appendCount);
       }
       final byte[] start = Arrays.copyOf(contents, FileCreateRequest.FILE_CREATE_MAX_SIZE);
-      final FileCreateRequest request = FileCreateRequest.of(start);
+      final FileCreateRequest request;
+      if (expirationTime != null) {
+        request = FileCreateRequest.of(start, expirationTime);
+      } else {
+        request = FileCreateRequest.of(start);
+      }
       final FileCreateResult result = protocolLayerClient.executeFileCreateTransaction(request);
       final FileId fileId = result.fileId();
       byte[] remaining =

--- a/hiero-enterprise-base/src/test/java/org/hiero/base/test/FileClientImplTest.java
+++ b/hiero-enterprise-base/src/test/java/org/hiero/base/test/FileClientImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -87,6 +88,37 @@ public class FileClientImplTest {
     verify(protocolLayerClient, times(1))
         .executeFileCreateTransaction(any(FileCreateRequest.class));
     verify(fileCreateResult, times(1)).fileId();
+    verify(protocolLayerClient, times(appendCount))
+        .executeFileAppendRequestTransaction(any(FileAppendRequest.class));
+    Assertions.assertEquals(fileId, result);
+  }
+
+  @Test
+  void testCreateFileWithExpirationForSizeGreaterThanFileCreateMaxSize() throws HieroException {
+    // mock
+    final FileId fileId = FileId.fromString("1.2.3");
+    final FileCreateResult fileCreateResult = Mockito.mock(FileCreateResult.class);
+    final FileAppendResult fileAppendResult = Mockito.mock(FileAppendResult.class);
+
+    // given
+    final byte[] content = new byte[FileCreateRequest.FILE_CREATE_MAX_SIZE * 2];
+    final Instant expirationTime = Instant.now().plusSeconds(120);
+    // -1 because 1 for executeFileCreateTransaction()
+    final int appendCount =
+        Math.floorDiv(content.length, FileCreateRequest.FILE_CREATE_MAX_SIZE) - 1;
+
+    // then
+    when(protocolLayerClient.executeFileCreateTransaction(any(FileCreateRequest.class)))
+        .thenReturn(fileCreateResult);
+    when(fileCreateResult.fileId()).thenReturn(fileId);
+    when(protocolLayerClient.executeFileAppendRequestTransaction(any(FileAppendRequest.class)))
+        .thenReturn(fileAppendResult);
+
+    final FileId result = fileClientImpl.createFile(content, expirationTime);
+
+    verify(protocolLayerClient, times(1))
+        .executeFileCreateTransaction(
+            argThat(request -> expirationTime.equals(request.expirationTime())));
     verify(protocolLayerClient, times(appendCount))
         .executeFileAppendRequestTransaction(any(FileAppendRequest.class));
     Assertions.assertEquals(fileId, result);


### PR DESCRIPTION
## **Problem**

`FileClientImpl.createFile(byte[], Instant)` silently drops the user-provided
`expirationTime` whenever the payload exceeds `FileCreateRequest.FILE_CREATE_MAX_SIZE`.


In `createFileImpl`, the small-file branch correctly picks between
`FileCreateRequest.of(contents)` and
`FileCreateRequest.of(contents, expirationTime)`
based on whether an expiration was supplied.

The multi-append branch unconditionally calls the one-arg factory:

```java
final byte[] start = Arrays.copyOf(contents, FileCreateRequest.FILE_CREATE_MAX_SIZE);
final FileCreateRequest request = FileCreateRequest.of(start); // expirationTime dropped
```

`FileCreateRequest.of(byte[])` hardcodes `expirationTime = null`, and
`ProtocolLayerClientImpl.executeFileCreateTransaction` only calls
`FileCreateTransaction.setExpirationTime(...)` when the request's expiration is non-null.

The result is that the underlying SDK transaction never receives the requested expiration,
so the created file falls back to the SDK/network default rather than the caller's value.

The `expirationTime` parameter is even validated earlier in the method
("must be in the future") before being silently discarded in this branch, which makes
the bug especially misleading.

---

## **Fix**

Mirror the small-file branching logic in the multi-append branch so the initial
FileCreate transaction carries the caller-supplied `expirationTime` when present.

No changes to the append path are needed — FileAppend transactions do not accept
an expiration.

---

## **Test**

Adds `testCreateFileWithExpirationForSizeGreaterThanFileCreateMaxSize`, which:

* calls `createFile(content, expirationTime)` with
  `content.length == FILE_CREATE_MAX_SIZE * 2`
* verifies the `FileCreateRequest` handed to `ProtocolLayerClient` carries the requested
  `expirationTime`
  (`argThat(request -> expirationTime.equals(request.expirationTime()))`)
* verifies the expected number of `FileAppend` transactions follow

All `FileClientImplTest` unit tests pass.


