### PR TITLE
fix: preserve REST error causes

### DIFF
--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/RestBasedPage.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/RestBasedPage.java
@@ -61,7 +61,7 @@ public class RestBasedPage<T> implements Page<T> {
       this.data = Collections.unmodifiableList(dataExtractionFunction.apply(jsonObject));
       this.nextPath = getNextPath(jsonObject);
     } catch (Exception e) {
-      throw new IllegalStateException("Can not parse JSON: " + e);
+      throw new IllegalStateException("Can not parse JSON", e);
     }
   }
 

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/ContractVerificationClientImplementation.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/ContractVerificationClientImplementation.java
@@ -56,28 +56,30 @@ public class ContractVerificationClientImplementation implements ContractVerific
       @NonNull final HttpRequest request, @NonNull final ClientHttpResponse response)
       throws IOException {
     Objects.requireNonNull(response, "response must not be null");
-    final String error;
+    final String body;
     try {
-      final String body = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
-      try {
-        final JsonNode rootNode = objectMapper.readTree(body);
-        final JsonNode errorNode = rootNode.get("error");
-        if (errorNode != null) {
-          error = errorNode.asText();
-        } else {
-          final JsonNode messageNode = rootNode.get("message");
-          if (messageNode != null) {
-            error = messageNode.asText();
-          } else {
-            error = body;
-          }
-        }
-      } catch (final Exception e) {
-        throw new IOException("Error parsing body as JSON: " + body, e);
-      }
+      body = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
     } catch (final Exception e) {
       throw new IOException(
-          "Error (" + response.getStatusCode() + "): " + response.getStatusText());
+          "Error (" + response.getStatusCode() + "): " + response.getStatusText(), e);
+    }
+
+    final String error;
+    try {
+      final JsonNode rootNode = objectMapper.readTree(body);
+      final JsonNode errorNode = rootNode.get("error");
+      if (errorNode != null) {
+        error = errorNode.asText();
+      } else {
+        final JsonNode messageNode = rootNode.get("message");
+        if (messageNode != null) {
+          error = messageNode.asText();
+        } else {
+          error = body;
+        }
+      }
+    } catch (final Exception e) {
+      throw new IOException("Error parsing body as JSON: " + body, e);
     }
     throw new IOException("Error (" + response.getStatusCode() + "): " + error);
   }
@@ -175,12 +177,7 @@ public class ContractVerificationClientImplementation implements ContractVerific
               .onStatus(
                   HttpStatusCode::is5xxServerError,
                   (request, response) -> {
-                    throw new RuntimeException(
-                        "Server error ("
-                            + response.getStatusCode()
-                            + ") for request '"
-                            + request.getURI()
-                            + "'");
+                    handleError(request, response);
                   })
               .body(String.class);
 

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeRestClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeRestClientImpl.java
@@ -3,16 +3,21 @@ package org.hiero.spring.implementation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.function.Function;
 import org.hiero.base.HieroException;
 import org.hiero.base.implementation.MirrorNodeRestClient;
+import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriBuilder;
 
 public class MirrorNodeRestClientImpl implements MirrorNodeRestClient<JsonNode> {
@@ -32,26 +37,27 @@ public class MirrorNodeRestClientImpl implements MirrorNodeRestClient<JsonNode> 
   }
 
   public JsonNode doGetCall(Function<UriBuilder, URI> uriFunction) throws HieroException {
-    final ResponseEntity<String> responseEntity =
-        restClient
-            .get()
-            .uri(uriBuilder -> uriFunction.apply(uriBuilder))
-            .accept(MediaType.APPLICATION_JSON)
-            .retrieve()
-            .onStatus(
-                HttpStatusCode::is4xxClientError,
-                (request, response) -> {
-                  if (!HttpStatus.NOT_FOUND.equals(response.getStatusCode())
-                      && !HttpStatus.BAD_REQUEST.equals(response.getStatusCode())) {
-                    throw new RuntimeException("Client error: " + response.getStatusText());
-                  }
-                })
-            .onStatus(
-                HttpStatusCode::is5xxServerError,
-                (request, response) -> {
-                  throw new RuntimeException("Server error: " + response.getStatusText());
-                })
-            .toEntity(String.class);
+    final ResponseEntity<String> responseEntity;
+    try {
+      responseEntity =
+          restClient
+              .get()
+              .uri(uriBuilder -> uriFunction.apply(uriBuilder))
+              .accept(MediaType.APPLICATION_JSON)
+              .retrieve()
+              .onStatus(
+                  HttpStatusCode::is4xxClientError,
+                  (request, response) -> {
+                    if (!HttpStatus.NOT_FOUND.equals(response.getStatusCode())
+                        && !HttpStatus.BAD_REQUEST.equals(response.getStatusCode())) {
+                      handleError(request, response);
+                    }
+                  })
+              .onStatus(HttpStatusCode::is5xxServerError, this::handleError)
+              .toEntity(String.class);
+    } catch (RestClientException e) {
+      throw new HieroException("Mirror Node call failed", e);
+    }
     final String body = responseEntity.getBody();
     try {
       if (HttpStatus.NOT_FOUND.equals(responseEntity.getStatusCode())
@@ -65,5 +71,17 @@ public class MirrorNodeRestClientImpl implements MirrorNodeRestClient<JsonNode> 
     } catch (JsonProcessingException e) {
       throw new HieroException("Error parsing body as JSON: " + body, e);
     }
+  }
+
+  private void handleError(final HttpRequest request, final ClientHttpResponse response)
+      throws IOException {
+    final String body = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+    throw new IOException(
+        "Mirror Node call failed with status "
+            + response.getStatusCode()
+            + " for request '"
+            + request.getURI()
+            + "': "
+            + body);
   }
 }

--- a/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/ContractVerificationErrorHandlingTest.java
+++ b/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/ContractVerificationErrorHandlingTest.java
@@ -1,0 +1,68 @@
+package org.hiero.spring.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.hiero.base.config.HieroConfig;
+import org.hiero.spring.implementation.ContractVerificationClientImplementation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
+
+class ContractVerificationErrorHandlingTest {
+
+  @Test
+  void preservesBodyReadFailureCause() throws Exception {
+    final ContractVerificationClientImplementation client =
+        new ContractVerificationClientImplementation(Mockito.mock(HieroConfig.class));
+    final Method handleError =
+        ContractVerificationClientImplementation.class.getDeclaredMethod(
+            "handleError", HttpRequest.class, ClientHttpResponse.class);
+    handleError.setAccessible(true);
+    final IOException readFailure = new IOException("stream closed");
+
+    final InvocationTargetException exception =
+        Assertions.assertThrows(
+            InvocationTargetException.class,
+            () ->
+                handleError.invoke(
+                    client, Mockito.mock(HttpRequest.class), failingResponse(readFailure)));
+
+    final Throwable cause = exception.getCause();
+    Assertions.assertInstanceOf(IOException.class, cause);
+    Assertions.assertSame(readFailure, cause.getCause());
+  }
+
+  private ClientHttpResponse failingResponse(final IOException readFailure) {
+    return new ClientHttpResponse() {
+      @Override
+      public HttpStatusCode getStatusCode() {
+        return HttpStatus.BAD_GATEWAY;
+      }
+
+      @Override
+      public String getStatusText() {
+        return "Bad Gateway";
+      }
+
+      @Override
+      public void close() {}
+
+      @Override
+      public InputStream getBody() throws IOException {
+        throw readFailure;
+      }
+
+      @Override
+      public HttpHeaders getHeaders() {
+        return HttpHeaders.EMPTY;
+      }
+    };
+  }
+}

--- a/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/MirrorNodeRestClientImplTest.java
+++ b/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/MirrorNodeRestClientImplTest.java
@@ -1,0 +1,51 @@
+package org.hiero.spring.test;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import org.hiero.base.HieroException;
+import org.hiero.spring.implementation.MirrorNodeRestClientImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class MirrorNodeRestClientImplTest {
+
+  @Test
+  void wrapsHttpErrorsInHieroException() {
+    final RestClient.Builder restClientBuilder =
+        RestClient.builder().baseUrl("https://mirror.example");
+    final MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
+    final MirrorNodeRestClientImpl client = new MirrorNodeRestClientImpl(restClientBuilder);
+
+    server
+        .expect(requestTo("https://mirror.example/api/v1/network/fees"))
+        .andRespond(
+            withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                .contentType(MediaType.TEXT_PLAIN)
+                .body("upstream failed"));
+
+    final HieroException exception =
+        Assertions.assertThrows(
+            HieroException.class, () -> client.doGetCall("/api/v1/network/fees"));
+
+    Assertions.assertEquals("Mirror Node call failed", exception.getMessage());
+    Assertions.assertNotNull(exception.getCause());
+    Assertions.assertTrue(hasCauseMessageContaining(exception, "upstream failed"));
+    server.verify();
+  }
+
+  private boolean hasCauseMessageContaining(final Throwable throwable, final String text) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (current.getMessage() != null && current.getMessage().contains(text)) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Wrap Spring mirror-node HTTP failures in `HieroException` instead of leaking generic `RuntimeException`.
- Preserve the original cause when contract verification error-body handling fails.
- Keep MicroProfile page JSON failures chained to their original cause.

## Test plan
- `./mvnw.cmd -pl hiero-enterprise-spring,hiero-enterprise-microprofile -am -DskipITs -Dtest=MirrorNodeRestClientImplTest,ContractVerificationErrorHandlingTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw.cmd -pl hiero-enterprise-spring,hiero-enterprise-microprofile spotless:check`