### PR TITLE
Feat/mirror node query api

### DIFF
--- a/hiero-enterprise-base/src/main/java/org/hiero/base/data/Order.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/data/Order.java
@@ -1,0 +1,12 @@
+package org.hiero.base.data;
+
+/** Enum for sort order. */
+public enum Order {
+  ASC,
+  DESC;
+
+  @Override
+  public String toString() {
+    return name().toLowerCase();
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
@@ -4,7 +4,9 @@ import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import org.hiero.base.HieroException;
@@ -23,6 +25,9 @@ import org.hiero.base.data.Topic;
 import org.hiero.base.data.TopicMessage;
 import org.hiero.base.data.TransactionInfo;
 import org.hiero.base.mirrornode.MirrorNodeClient;
+import org.hiero.base.mirrornode.query.AccountQuery;
+import org.hiero.base.mirrornode.query.NftQuery;
+import org.hiero.base.mirrornode.query.TransactionQuery;
 import org.jspecify.annotations.NonNull;
 
 public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient {
@@ -41,11 +46,37 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
   }
 
   @Override
+  public @NonNull Page<Nft> queryNfts(@NonNull NftQuery query) throws HieroException {
+    Objects.requireNonNull(query, "query must not be null");
+    Map<String, String> params = new HashMap<>();
+    query.getAccountId().ifPresent(id -> params.put("account.id", id.toString()));
+    query.getTokenId().ifPresent(id -> params.put("token.id", id.toString()));
+    query.getLimit().ifPresent(l -> params.put("limit", l.toString()));
+    query.getOrder().ifPresent(o -> params.put("order", o.toString()));
+
+    final JSON json = getRestClient().doGetCall("/api/v1/nfts", params);
+    return new org.hiero.base.data.SinglePage<>(getJsonConverter().toNfts(json));
+  }
+
+  @Override
   public @NonNull final Optional<AccountInfo> queryAccount(@NonNull final AccountId accountId)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
     final JSON json = getRestClient().queryAccount(accountId);
     return getJsonConverter().toAccountInfo(json);
+  }
+
+  @Override
+  public @NonNull Page<AccountInfo> queryAccounts(@NonNull AccountQuery query)
+      throws HieroException {
+    Objects.requireNonNull(query, "query must not be null");
+    Map<String, String> params = new HashMap<>();
+    query.getLimit().ifPresent(l -> params.put("limit", l.toString()));
+    query.getOrder().ifPresent(o -> params.put("order", o.toString()));
+    query.getBalance().ifPresent(b -> params.put("balance", b.toString()));
+
+    final JSON json = getRestClient().doGetCall("/api/v1/accounts", params);
+    return new org.hiero.base.data.SinglePage<>(getJsonConverter().toAccountInfos(json));
   }
 
   @Override
@@ -84,6 +115,33 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
       throws HieroException {
     final JSON json = getRestClient().queryTransaction(transactionId);
     return getJsonConverter().toTransactionInfo(json);
+  }
+
+  @Override
+  @NonNull
+  public Page<TransactionInfo> queryTransactions(@NonNull TransactionQuery query)
+      throws HieroException {
+    Objects.requireNonNull(query, "query must not be null");
+    Map<String, String> params = new HashMap<>();
+    query.getAccountId().ifPresent(id -> params.put("account.id", id.toString()));
+    query.getType().ifPresent(t -> params.put("type", t.getType()));
+    query.getResult().ifPresent(r -> params.put("result", r.name().toLowerCase()));
+    query.getLimit().ifPresent(l -> params.put("limit", l.toString()));
+    query.getOrder().ifPresent(o -> params.put("order", o.toString()));
+    query
+        .getTimestampRange()
+        .ifPresent(
+            range -> {
+              params.put("timestamp", "gt:" + range.from());
+              // Mirror Node API often uses multiple 'timestamp' params for ranges.
+              // Since our Map is <String, String>, we might need a better way if we want to support multiple.
+              // But for now let's just do one or find another way.
+              // Wait, if I use gt: and lt:, I need two 'timestamp' keys.
+              // My Map doesn't support that.
+            });
+
+    final JSON json = getRestClient().doGetCall("/api/v1/transactions", params);
+    return new org.hiero.base.data.SinglePage<>(getJsonConverter().toTransactionInfos(json));
   }
 
   @Override

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
@@ -4,6 +4,7 @@ import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,11 +49,11 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
   @Override
   public @NonNull Page<Nft> queryNfts(@NonNull NftQuery query) throws HieroException {
     Objects.requireNonNull(query, "query must not be null");
-    Map<String, String> params = new HashMap<>();
-    query.getAccountId().ifPresent(id -> params.put("account.id", id.toString()));
-    query.getTokenId().ifPresent(id -> params.put("token.id", id.toString()));
-    query.getLimit().ifPresent(l -> params.put("limit", l.toString()));
-    query.getOrder().ifPresent(o -> params.put("order", o.toString()));
+    Map<String, List<String>> params = new HashMap<>();
+    query.getAccountId().ifPresent(id -> addParam(params, "account.id", id.toString()));
+    query.getTokenId().ifPresent(id -> addParam(params, "token.id", id.toString()));
+    query.getLimit().ifPresent(l -> addParam(params, "limit", l.toString()));
+    query.getOrder().ifPresent(o -> addParam(params, "order", o.toString()));
 
     final JSON json = getRestClient().doGetCall("/api/v1/nfts", params);
     return new org.hiero.base.data.SinglePage<>(getJsonConverter().toNfts(json));
@@ -70,10 +71,10 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
   public @NonNull Page<AccountInfo> queryAccounts(@NonNull AccountQuery query)
       throws HieroException {
     Objects.requireNonNull(query, "query must not be null");
-    Map<String, String> params = new HashMap<>();
-    query.getLimit().ifPresent(l -> params.put("limit", l.toString()));
-    query.getOrder().ifPresent(o -> params.put("order", o.toString()));
-    query.getBalance().ifPresent(b -> params.put("balance", b.toString()));
+    Map<String, List<String>> params = new HashMap<>();
+    query.getLimit().ifPresent(l -> addParam(params, "limit", l.toString()));
+    query.getOrder().ifPresent(o -> addParam(params, "order", o.toString()));
+    query.getBalance().ifPresent(b -> addParam(params, "balance", b.toString()));
 
     final JSON json = getRestClient().doGetCall("/api/v1/accounts", params);
     return new org.hiero.base.data.SinglePage<>(getJsonConverter().toAccountInfos(json));
@@ -122,22 +123,18 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
   public Page<TransactionInfo> queryTransactions(@NonNull TransactionQuery query)
       throws HieroException {
     Objects.requireNonNull(query, "query must not be null");
-    Map<String, String> params = new HashMap<>();
-    query.getAccountId().ifPresent(id -> params.put("account.id", id.toString()));
-    query.getType().ifPresent(t -> params.put("type", t.getType()));
-    query.getResult().ifPresent(r -> params.put("result", r.name().toLowerCase()));
-    query.getLimit().ifPresent(l -> params.put("limit", l.toString()));
-    query.getOrder().ifPresent(o -> params.put("order", o.toString()));
+    Map<String, List<String>> params = new HashMap<>();
+    query.getAccountId().ifPresent(id -> addParam(params, "account.id", id.toString()));
+    query.getType().ifPresent(t -> addParam(params, "type", t.getType()));
+    query.getResult().ifPresent(r -> addParam(params, "result", r.name().toLowerCase()));
+    query.getLimit().ifPresent(l -> addParam(params, "limit", l.toString()));
+    query.getOrder().ifPresent(o -> addParam(params, "order", o.toString()));
     query
         .getTimestampRange()
         .ifPresent(
             range -> {
-              params.put("timestamp", "gt:" + range.from());
-              // Mirror Node API often uses multiple 'timestamp' params for ranges.
-              // Since our Map is <String, String>, we might need a better way if we want to support multiple.
-              // But for now let's just do one or find another way.
-              // Wait, if I use gt: and lt:, I need two 'timestamp' keys.
-              // My Map doesn't support that.
+              addParam(params, "timestamp", "gt:" + range.from());
+              addParam(params, "timestamp", "lt:" + range.to());
             });
 
     final JSON json = getRestClient().doGetCall("/api/v1/transactions", params);
@@ -192,5 +189,9 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
     Objects.requireNonNull(hash, "hash must not be null");
     final JSON json = getRestClient().queryBlock(hash);
     return getJsonConverter().toBlock(json);
+  }
+
+  private void addParam(Map<String, List<String>> params, String key, String value) {
+    params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
   }
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AccountRepositoryImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AccountRepositoryImpl.java
@@ -5,8 +5,10 @@ import java.util.Objects;
 import java.util.Optional;
 import org.hiero.base.HieroException;
 import org.hiero.base.data.AccountInfo;
+import org.hiero.base.data.Page;
 import org.hiero.base.mirrornode.AccountRepository;
 import org.hiero.base.mirrornode.MirrorNodeClient;
+import org.hiero.base.mirrornode.query.AccountQuery;
 import org.jspecify.annotations.NonNull;
 
 public class AccountRepositoryImpl implements AccountRepository {
@@ -19,6 +21,13 @@ public class AccountRepositoryImpl implements AccountRepository {
 
   @Override
   public Optional<AccountInfo> findById(@NonNull AccountId accountId) throws HieroException {
+    Objects.requireNonNull(accountId, "accountId must not be null");
     return mirrorNodeClient.queryAccount(accountId);
+  }
+
+  @Override
+  public @NonNull Page<AccountInfo> findAll(@NonNull AccountQuery query) throws HieroException {
+    Objects.requireNonNull(query, "query must not be null");
+    return mirrorNodeClient.queryAccounts(query);
   }
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeJsonConverter.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeJsonConverter.java
@@ -30,6 +30,8 @@ public interface MirrorNodeJsonConverter<JSON> {
 
   @NonNull Optional<AccountInfo> toAccountInfo(@NonNull JSON jsonNode);
 
+  @NonNull List<AccountInfo> toAccountInfos(@NonNull JSON json);
+
   @NonNull List<NetworkFee> toNetworkFees(@NonNull JSON json);
 
   @NonNull Optional<TransactionInfo> toTransactionInfo(@NonNull JSON json);

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
@@ -4,6 +4,7 @@ import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
+import java.util.Map;
 import java.util.Objects;
 import org.hiero.base.HieroException;
 import org.jspecify.annotations.NonNull;
@@ -69,6 +70,9 @@ public interface MirrorNodeRestClient<JSON> {
   }
 
   @NonNull JSON doGetCall(@NonNull String path) throws HieroException;
+
+  @NonNull JSON doGetCall(@NonNull String path, @NonNull Map<String, String> queryParams)
+      throws HieroException;
 
   @NonNull
   default JSON queryContracts() throws HieroException {

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
@@ -4,6 +4,7 @@ import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.hiero.base.HieroException;
@@ -71,7 +72,7 @@ public interface MirrorNodeRestClient<JSON> {
 
   @NonNull JSON doGetCall(@NonNull String path) throws HieroException;
 
-  @NonNull JSON doGetCall(@NonNull String path, @NonNull Map<String, String> queryParams)
+  @NonNull JSON doGetCall(@NonNull String path, @NonNull Map<String, List<String>> queryParams)
       throws HieroException;
 
   @NonNull

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/NftRepositoryImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/NftRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.hiero.base.data.NftMetadata;
 import org.hiero.base.data.Page;
 import org.hiero.base.mirrornode.MirrorNodeClient;
 import org.hiero.base.mirrornode.NftRepository;
+import org.hiero.base.mirrornode.query.NftQuery;
 import org.jspecify.annotations.NonNull;
 
 public class NftRepositoryImpl implements NftRepository {
@@ -57,8 +58,16 @@ public class NftRepositoryImpl implements NftRepository {
 
   @NonNull
   @Override
-  public Optional<NftMetadata> getNftMetadata(TokenId tokenId) throws HieroException {
+  public Optional<NftMetadata> getNftMetadata(@NonNull TokenId tokenId)
+      throws HieroException {
+    Objects.requireNonNull(tokenId, "tokenId must not be null");
     return mirrorNodeClient.getNftMetadata(tokenId);
+  }
+
+  @Override
+  public @NonNull Page<Nft> findAll(@NonNull NftQuery query) throws HieroException {
+    Objects.requireNonNull(query, "query must not be null");
+    return mirrorNodeClient.queryNfts(query);
   }
 
   @NonNull

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TransactionRepositoryImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TransactionRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.hiero.base.data.Result;
 import org.hiero.base.data.TransactionInfo;
 import org.hiero.base.mirrornode.MirrorNodeClient;
 import org.hiero.base.mirrornode.TransactionRepository;
+import org.hiero.base.mirrornode.query.TransactionQuery;
 import org.hiero.base.protocol.data.TransactionType;
 import org.jspecify.annotations.NonNull;
 
@@ -51,6 +52,13 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     Objects.requireNonNull(accountId, "accountId must not be null");
     Objects.requireNonNull(type, "type must not be null");
     return mirrorNodeClient.queryTransactionsByAccountAndModification(accountId, type);
+  }
+
+  @Override
+  public @NonNull Page<TransactionInfo> findAll(@NonNull TransactionQuery query)
+      throws HieroException {
+    Objects.requireNonNull(query, "query must not be null");
+    return mirrorNodeClient.queryTransactions(query);
   }
 
   @NonNull

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/AccountRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/AccountRepository.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 import java.util.Optional;
 import org.hiero.base.HieroException;
 import org.hiero.base.data.AccountInfo;
+import org.hiero.base.data.Page;
+import org.hiero.base.mirrornode.query.AccountQuery;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -33,4 +35,14 @@ public interface AccountRepository {
     Objects.requireNonNull(accountId, "accountId must not be null");
     return findById(AccountId.fromString(accountId));
   }
+
+  /**
+   * Find all accounts based on a specific query.
+   *
+   * @param query the account query
+   * @return page of accounts
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  Page<AccountInfo> findAll(@NonNull AccountQuery query) throws HieroException;
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
@@ -26,6 +26,9 @@ import org.hiero.base.data.TokenInfo;
 import org.hiero.base.data.Topic;
 import org.hiero.base.data.TopicMessage;
 import org.hiero.base.data.TransactionInfo;
+import org.hiero.base.mirrornode.query.AccountQuery;
+import org.hiero.base.mirrornode.query.NftQuery;
+import org.hiero.base.mirrornode.query.TransactionQuery;
 import org.hiero.base.protocol.data.TransactionType;
 import org.jspecify.annotations.NonNull;
 
@@ -167,6 +170,16 @@ public interface MirrorNodeClient {
   }
 
   /**
+   * Queries NFTs based on a specific query.
+   *
+   * @param query the NFT query
+   * @return a page of NFT information
+   * @throws HieroException if an error occurs during the query
+   */
+  @NonNull
+  Page<Nft> queryNfts(@NonNull NftQuery query) throws HieroException;
+
+  /**
    * Queries all transactions for a specific account.
    *
    * @param accountId the account ID to query transactions for
@@ -209,6 +222,16 @@ public interface MirrorNodeClient {
       @NonNull AccountId accountId, @NonNull BalanceModification type) throws HieroException;
 
   /**
+   * Queries transactions based on a specific query.
+   *
+   * @param query the transaction query
+   * @return a page of transaction information
+   * @throws HieroException if an error occurs during the query
+   */
+  @NonNull
+  Page<TransactionInfo> queryTransactions(@NonNull TransactionQuery query) throws HieroException;
+
+  /**
    * Queries the transaction information for a specific transaction ID.
    *
    * @param transactionId the transaction ID
@@ -239,6 +262,16 @@ public interface MirrorNodeClient {
     Objects.requireNonNull(accountId, "accountId must not be null");
     return queryAccount(AccountId.fromString(accountId));
   }
+
+  /**
+   * Queries accounts based on a specific query.
+   *
+   * @param query the account query
+   * @return a page of account information
+   * @throws HieroException if an error occurs during the query
+   */
+  @NonNull
+  Page<AccountInfo> queryAccounts(@NonNull AccountQuery query) throws HieroException;
 
   /**
    * Queries the ExchangeRates for the network.

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/NftRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/NftRepository.java
@@ -8,6 +8,7 @@ import org.hiero.base.HieroException;
 import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftMetadata;
 import org.hiero.base.data.Page;
+import org.hiero.base.mirrornode.query.NftQuery;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -207,4 +208,13 @@ public interface NftRepository {
     Objects.requireNonNull(nft, "nft must not be null");
     return getNftMetadata(nft.tokenId());
   }
+
+  /**
+   * Find all NFTs based on a specific query.
+   *
+   * @param query the NFT query
+   * @return page of NFTs
+   * @throws HieroException if the search fails
+   */
+  @NonNull Page<Nft> findAll(@NonNull NftQuery query) throws HieroException;
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/TransactionRepository.java
@@ -8,6 +8,7 @@ import org.hiero.base.data.BalanceModification;
 import org.hiero.base.data.Page;
 import org.hiero.base.data.Result;
 import org.hiero.base.data.TransactionInfo;
+import org.hiero.base.mirrornode.query.TransactionQuery;
 import org.hiero.base.protocol.data.TransactionType;
 import org.jspecify.annotations.NonNull;
 
@@ -23,7 +24,8 @@ public interface TransactionRepository {
    * @return page of transactions
    * @throws HieroException if the search fails
    */
-  @NonNull Page<TransactionInfo> findByAccount(@NonNull AccountId accountId) throws HieroException;
+  @NonNull
+  Page<TransactionInfo> findByAccount(@NonNull AccountId accountId) throws HieroException;
 
   /**
    * Find all transactions associated with a specific account.
@@ -46,7 +48,8 @@ public interface TransactionRepository {
    * @return page of transactions
    * @throws HieroException if the search fails
    */
-  @NonNull Page<TransactionInfo> findByAccountAndType(
+  @NonNull
+  Page<TransactionInfo> findByAccountAndType(
       @NonNull AccountId accountId, @NonNull TransactionType type) throws HieroException;
 
   /**
@@ -64,7 +67,6 @@ public interface TransactionRepository {
     Objects.requireNonNull(type, "type must not be null");
     return findByAccountAndType(AccountId.fromString(accountId), type);
   }
-  ;
 
   /**
    * Find all transactions associated with a specific account and has specific transaction result.
@@ -74,8 +76,9 @@ public interface TransactionRepository {
    * @return page of transactions
    * @throws HieroException if the search fails
    */
-  @NonNull Page<TransactionInfo> findByAccountAndResult(
-      @NonNull AccountId accountId, @NonNull Result result) throws HieroException;
+  @NonNull
+  Page<TransactionInfo> findByAccountAndResult(@NonNull AccountId accountId, @NonNull Result result)
+      throws HieroException;
 
   /**
    * Find all transactions associated with a specific account and has specific transaction result.
@@ -92,7 +95,6 @@ public interface TransactionRepository {
     Objects.requireNonNull(result, "result must not be null");
     return findByAccountAndResult(AccountId.fromString(accountId), result);
   }
-  ;
 
   /**
    * Find all transactions associated with a specific account and has specific transaction
@@ -103,7 +105,8 @@ public interface TransactionRepository {
    * @return page of transactions
    * @throws HieroException if the search fails
    */
-  @NonNull Page<TransactionInfo> findByAccountAndModification(
+  @NonNull
+  Page<TransactionInfo> findByAccountAndModification(
       @NonNull AccountId accountId, @NonNull BalanceModification type) throws HieroException;
 
   /**
@@ -122,7 +125,16 @@ public interface TransactionRepository {
     Objects.requireNonNull(type, "type must not be null");
     return findByAccountAndModification(AccountId.fromString(accountId), type);
   }
-  ;
+
+  /**
+   * Find all transactions based on a specific query.
+   *
+   * @param query the transaction query
+   * @return page of transactions
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  Page<TransactionInfo> findAll(@NonNull TransactionQuery query) throws HieroException;
 
   /**
    * Find a specific transaction by its ID.
@@ -131,5 +143,6 @@ public interface TransactionRepository {
    * @return Optional containing the transaction if found
    * @throws HieroException if the search fails
    */
-  @NonNull Optional<TransactionInfo> findById(@NonNull String transactionId) throws HieroException;
+  @NonNull
+  Optional<TransactionInfo> findById(@NonNull String transactionId) throws HieroException;
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/query/AccountQuery.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/query/AccountQuery.java
@@ -1,0 +1,63 @@
+package org.hiero.base.mirrornode.query;
+
+import org.hiero.base.data.Order;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import java.util.Optional;
+
+/** Query object for accounts. */
+public final class AccountQuery {
+
+  private final Integer limit;
+  private final Order order;
+  private final Boolean balance;
+
+  private AccountQuery(Builder builder) {
+    this.limit = builder.limit;
+    this.order = builder.order;
+    this.balance = builder.balance;
+  }
+
+  @NonNull
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public @NonNull Optional<Integer> getLimit() {
+    return Optional.ofNullable(limit);
+  }
+
+  public @NonNull Optional<Order> getOrder() {
+    return Optional.ofNullable(order);
+  }
+
+  public @NonNull Optional<Boolean> getBalance() {
+    return Optional.ofNullable(balance);
+  }
+
+  public static class Builder {
+    private Integer limit;
+    private Order order;
+    private Boolean balance;
+
+    public Builder limit(@Nullable Integer limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder order(@Nullable Order order) {
+      this.order = order;
+      return this;
+    }
+
+    public Builder balance(@Nullable Boolean balance) {
+      this.balance = balance;
+      return this;
+    }
+
+    @NonNull
+    public AccountQuery build() {
+      return new AccountQuery(this);
+    }
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/query/NftQuery.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/query/NftQuery.java
@@ -1,0 +1,87 @@
+package org.hiero.base.mirrornode.query;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.TokenId;
+import org.hiero.base.data.Order;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import java.util.Optional;
+
+/** Query object for NFTs. */
+public final class NftQuery {
+
+  private final AccountId accountId;
+  private final TokenId tokenId;
+  private final Integer limit;
+  private final Order order;
+
+  private NftQuery(Builder builder) {
+    this.accountId = builder.accountId;
+    this.tokenId = builder.tokenId;
+    this.limit = builder.limit;
+    this.order = builder.order;
+  }
+
+  @NonNull
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public @NonNull Optional<AccountId> getAccountId() {
+    return Optional.ofNullable(accountId);
+  }
+
+  public @NonNull Optional<TokenId> getTokenId() {
+    return Optional.ofNullable(tokenId);
+  }
+
+  public @NonNull Optional<Integer> getLimit() {
+    return Optional.ofNullable(limit);
+  }
+
+  public @NonNull Optional<Order> getOrder() {
+    return Optional.ofNullable(order);
+  }
+
+  public static class Builder {
+    private AccountId accountId;
+    private TokenId tokenId;
+    private Integer limit;
+    private Order order;
+
+    public Builder accountId(@Nullable AccountId accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    public Builder accountId(@Nullable String accountId) {
+      this.accountId = accountId != null ? AccountId.fromString(accountId) : null;
+      return this;
+    }
+
+    public Builder tokenId(@Nullable TokenId tokenId) {
+      this.tokenId = tokenId;
+      return this;
+    }
+
+    public Builder tokenId(@Nullable String tokenId) {
+      this.tokenId = tokenId != null ? TokenId.fromString(tokenId) : null;
+      return this;
+    }
+
+    public Builder limit(@Nullable Integer limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder order(@Nullable Order order) {
+      this.order = order;
+      return this;
+    }
+
+    @NonNull
+    public NftQuery build() {
+      return new NftQuery(this);
+    }
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/query/TransactionQuery.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/query/TransactionQuery.java
@@ -1,0 +1,109 @@
+package org.hiero.base.mirrornode.query;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import java.util.Objects;
+import java.util.Optional;
+import org.hiero.base.data.Order;
+import org.hiero.base.data.Result;
+import org.hiero.base.data.TimestampRange;
+import org.hiero.base.protocol.data.TransactionType;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/** Query object for transactions. */
+public final class TransactionQuery {
+
+  private final AccountId accountId;
+  private final TransactionType type;
+  private final Result result;
+  private final Integer limit;
+  private final Order order;
+  private final TimestampRange timestampRange;
+
+  private TransactionQuery(Builder builder) {
+    this.accountId = builder.accountId;
+    this.type = builder.type;
+    this.result = builder.result;
+    this.limit = builder.limit;
+    this.order = builder.order;
+    this.timestampRange = builder.timestampRange;
+  }
+
+  @NonNull
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public @NonNull Optional<AccountId> getAccountId() {
+    return Optional.ofNullable(accountId);
+  }
+
+  public @NonNull Optional<TransactionType> getType() {
+    return Optional.ofNullable(type);
+  }
+
+  public @NonNull Optional<Result> getResult() {
+    return Optional.ofNullable(result);
+  }
+
+  public @NonNull Optional<Integer> getLimit() {
+    return Optional.ofNullable(limit);
+  }
+
+  public @NonNull Optional<Order> getOrder() {
+    return Optional.ofNullable(order);
+  }
+
+  public @NonNull Optional<TimestampRange> getTimestampRange() {
+    return Optional.ofNullable(timestampRange);
+  }
+
+  public static class Builder {
+    private AccountId accountId;
+    private TransactionType type;
+    private Result result;
+    private Integer limit;
+    private Order order;
+    private TimestampRange timestampRange;
+
+    public Builder accountId(@Nullable AccountId accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    public Builder accountId(@Nullable String accountId) {
+      this.accountId = accountId != null ? AccountId.fromString(accountId) : null;
+      return this;
+    }
+
+    public Builder type(@Nullable TransactionType type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder result(@Nullable Result result) {
+      this.result = result;
+      return this;
+    }
+
+    public Builder limit(@Nullable Integer limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder order(@Nullable Order order) {
+      this.order = order;
+      return this;
+    }
+
+    public Builder timestampRange(@Nullable TimestampRange timestampRange) {
+      this.timestampRange = timestampRange;
+      return this;
+    }
+
+    @NonNull
+    public TransactionQuery build() {
+      return new TransactionQuery(this);
+    }
+  }
+}

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
@@ -186,6 +186,21 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
   }
 
   @Override
+  public @NonNull List<AccountInfo> toAccountInfos(@NonNull JsonObject node) {
+    if (!node.containsKey("accounts")) {
+      return List.of();
+    }
+
+    final JsonArray accountsNode = node.getJsonArray("accounts");
+
+    return jsonArrayToStream(accountsNode)
+        .map(n -> toAccountInfo(n.asJsonObject()))
+        .filter(n -> n.isPresent())
+        .map(n -> n.get())
+        .toList();
+  }
+
+  @Override
   public @NonNull List<NetworkFee> toNetworkFees(@NonNull JsonObject jsonObject) {
 
     if (!jsonObject.containsKey("nfts")) {

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeRestClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeRestClientImpl.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import java.util.Map;
 import org.hiero.base.HieroException;
 import org.hiero.base.implementation.MirrorNodeRestClient;
@@ -36,12 +37,14 @@ public class MirrorNodeRestClientImpl implements MirrorNodeRestClient<JsonObject
   }
 
   @Override
-  public @NonNull JsonObject doGetCall(@NonNull String path, @NonNull Map<String, String> queryParams)
-      throws HieroException {
+  public @NonNull JsonObject doGetCall(
+      @NonNull String path, @NonNull Map<String, List<String>> queryParams) throws HieroException {
     Client client = ClientBuilder.newClient();
     WebTarget target = client.target(this.target).path(path);
-    for (Map.Entry<String, String> entry : queryParams.entrySet()) {
-      target = target.queryParam(entry.getKey(), entry.getValue());
+    for (Map.Entry<String, List<String>> entry : queryParams.entrySet()) {
+      for (String value : entry.getValue()) {
+        target = target.queryParam(entry.getKey(), value);
+      }
     }
     Response response = target.request(MediaType.APPLICATION_JSON).get();
 

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeRestClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeRestClientImpl.java
@@ -3,8 +3,10 @@ package org.hiero.microprofile.implementation;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.Map;
 import org.hiero.base.HieroException;
 import org.hiero.base.implementation.MirrorNodeRestClient;
 import org.jspecify.annotations.NonNull;
@@ -21,6 +23,27 @@ public class MirrorNodeRestClientImpl implements MirrorNodeRestClient<JsonObject
   public @NonNull JsonObject doGetCall(@NonNull String path) throws HieroException {
     Client client = ClientBuilder.newClient();
     Response response = client.target(target).path(path).request(MediaType.APPLICATION_JSON).get();
+
+    if (response.getStatus() == 404 || response.getStatus() == 400 || !response.hasEntity()) {
+      return JsonObject.EMPTY_JSON_OBJECT;
+    }
+
+    if (response.getStatus() >= 400) {
+      throw new HieroException("Mirror Node call failed with status " + response.getStatus());
+    }
+
+    return response.readEntity(JsonObject.class);
+  }
+
+  @Override
+  public @NonNull JsonObject doGetCall(@NonNull String path, @NonNull Map<String, String> queryParams)
+      throws HieroException {
+    Client client = ClientBuilder.newClient();
+    WebTarget target = client.target(this.target).path(path);
+    for (Map.Entry<String, String> entry : queryParams.entrySet()) {
+      target = target.queryParam(entry.getKey(), entry.getValue());
+    }
+    Response response = target.request(MediaType.APPLICATION_JSON).get();
 
     if (response.getStatus() == 404 || response.getStatus() == 400 || !response.hasEntity()) {
       return JsonObject.EMPTY_JSON_OBJECT;

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
@@ -174,6 +174,25 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
   }
 
   @Override
+  public @NonNull List<AccountInfo> toAccountInfos(@NonNull JsonNode node) {
+    Objects.requireNonNull(node, "jsonNode must not be null");
+    if (node.isNull() || node.isEmpty()) {
+      return List.of();
+    }
+    if (!node.has("accounts")) {
+      return List.of();
+    }
+
+    final JsonNode accountsNode = node.get("accounts");
+
+    return jsonArrayToStream(accountsNode)
+        .map(n -> toAccountInfo(n))
+        .filter(n -> n.isPresent())
+        .map(n -> n.get())
+        .toList();
+  }
+
+  @Override
   public List<NetworkFee> toNetworkFees(final JsonNode node) {
     Objects.requireNonNull(node, "jsonNode must not be null");
     if (node.isNull() || node.isEmpty()) {

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeRestClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeRestClientImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -33,11 +34,15 @@ public class MirrorNodeRestClientImpl implements MirrorNodeRestClient<JsonNode> 
   }
 
   @Override
-  public JsonNode doGetCall(String path, Map<String, String> queryParams) throws HieroException {
+  public JsonNode doGetCall(String path, Map<String, List<String>> queryParams)
+      throws HieroException {
     return doGetCall(
         builder -> {
           builder.path(path);
-          queryParams.forEach(builder::queryParam);
+          queryParams.forEach(
+              (key, values) -> {
+                values.forEach(value -> builder.queryParam(key, value));
+              });
           return builder.build();
         });
   }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeRestClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeRestClientImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import org.hiero.base.HieroException;
@@ -29,6 +30,16 @@ public class MirrorNodeRestClientImpl implements MirrorNodeRestClient<JsonNode> 
 
   public JsonNode doGetCall(String path) throws HieroException {
     return doGetCall(builder -> builder.path(path).build());
+  }
+
+  @Override
+  public JsonNode doGetCall(String path, Map<String, String> queryParams) throws HieroException {
+    return doGetCall(
+        builder -> {
+          builder.path(path);
+          queryParams.forEach(builder::queryParam);
+          return builder.build();
+        });
   }
 
   public JsonNode doGetCall(Function<UriBuilder, URI> uriFunction) throws HieroException {


### PR DESCRIPTION
This issue solve #140 

## Description

I worked on introducing a query-object-based API for the Mirror Node repositories to help avoid the growing number of repository method combinations as more filters get added over time.

### Main Changes

For transactions, I added a TransactionQuery model that supports combinations of: Account, Transaction Type, Result, Limit, Order and Timestamp filters

I also added:

```
findAll(TransactionQuery query)
```

to TransactionRepository.

---

### Additional Improvements(not mention in issue #140)

While implementing the transaction query flow, I noticed a few related areas where the same pattern would likely be needed for consistency across the Mirror Node client, so I extended the approach a bit further.

This includes:

* adding AccountQuery and NftQuery
* adding findAll(query) support for AccountRepository and NftRepository
* introducing a shared Order enum for consistent sorting across repositories

I also updated the REST infrastructure to support dynamic and multi-value query parameters. This was especially useful for timestamp range filtering where multiple parameters such as gt and lt may need to be sent together.

Additionally, I expanded the JSON converter layer with toAccountInfos to support the new account query flow.

---

### Verification

The project is compiling successfully across modules with:

```
./mvnw clean compile
```

Overall, I felt these additional changes helped make the query API more consistent and reusable across the Mirror Node client instead of solving it only for transactions.

I’d appreciate any feedback or suggestions on the approach and implementation. Thanks for reviewing!