### PR TITLE
feat(mirror-node): implement NFT metadata and type queries

### DIFF
--- a/hiero-enterprise-base/src/main/java/org/hiero/base/data/MappedPage.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/data/MappedPage.java
@@ -1,0 +1,59 @@
+package org.hiero.base.data;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * {@link Page} adapter that maps items from another page while preserving pagination behavior.
+ *
+ * @param <S> source element type
+ * @param <T> target element type
+ */
+public final class MappedPage<S, T> implements Page<T> {
+
+  private final Page<S> delegate;
+
+  private final Function<S, Optional<T>> mapper;
+
+  public MappedPage(final Page<S> delegate, final Function<S, Optional<T>> mapper) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+    this.mapper = Objects.requireNonNull(mapper, "mapper must not be null");
+  }
+
+  @Override
+  public int getPageIndex() {
+    return delegate.getPageIndex();
+  }
+
+  @Override
+  public int getSize() {
+    return getData().size();
+  }
+
+  @Override
+  public List<T> getData() {
+    return delegate.getData().stream().map(mapper).flatMap(Optional::stream).toList();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return delegate.hasNext();
+  }
+
+  @Override
+  public Page<T> next() {
+    return new MappedPage<>(delegate.next(), mapper);
+  }
+
+  @Override
+  public Page<T> first() {
+    return new MappedPage<>(delegate.first(), mapper);
+  }
+
+  @Override
+  public boolean isFirst() {
+    return delegate.isFirst();
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
@@ -3,6 +3,7 @@ package org.hiero.base.implementation;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.TokenId;
+import com.hedera.hashgraph.sdk.TokenType;
 import com.hedera.hashgraph.sdk.TopicId;
 import java.util.List;
 import java.util.Objects;
@@ -18,6 +19,7 @@ import org.hiero.base.data.NetworkSupplies;
 import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftMetadata;
 import org.hiero.base.data.Page;
+import org.hiero.base.data.Token;
 import org.hiero.base.data.TokenInfo;
 import org.hiero.base.data.Topic;
 import org.hiero.base.data.TopicMessage;
@@ -103,7 +105,29 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
 
   @Override
   public @NonNull Optional<NftMetadata> getNftMetadata(TokenId tokenId) throws HieroException {
-    throw new UnsupportedOperationException("Not yet implemented");
+    Objects.requireNonNull(tokenId, "tokenId must not be null");
+    return queryTokenById(tokenId)
+        .filter(tokenInfo -> tokenInfo.type() == TokenType.NON_FUNGIBLE_UNIQUE)
+        .map(
+            tokenInfo ->
+                new NftMetadata(
+                    tokenInfo.tokenId(),
+                    tokenInfo.name(),
+                    tokenInfo.symbol(),
+                    tokenInfo.treasuryAccountId()));
+  }
+
+  protected final @NonNull Optional<NftMetadata> resolveNftMetadata(@NonNull final Token token) {
+    Objects.requireNonNull(token, "token must not be null");
+    if (token.type() != TokenType.NON_FUNGIBLE_UNIQUE || token.tokenId() == null) {
+      return Optional.empty();
+    }
+    try {
+      return getNftMetadata(token.tokenId());
+    } catch (final HieroException e) {
+      throw new IllegalStateException(
+          "Error resolving NFT metadata for token " + token.tokenId(), e);
+    }
   }
 
   @Override

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -11,6 +11,7 @@ import org.hiero.base.HieroException;
 import org.hiero.base.data.Balance;
 import org.hiero.base.data.BalanceModification;
 import org.hiero.base.data.Block;
+import org.hiero.base.data.MappedPage;
 import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftMetadata;
 import org.hiero.base.data.Page;
@@ -145,12 +146,22 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
   @Override
   public @NonNull Page<NftMetadata> findNftTypesByOwner(AccountId ownerId) {
-    throw new RuntimeException("Not implemented");
+    Objects.requireNonNull(ownerId, "ownerId must not be null");
+    try {
+      return new MappedPage<>(queryTokensForAccount(ownerId), this::resolveNftMetadata);
+    } catch (final HieroException e) {
+      throw new IllegalStateException("Error querying NFT types for owner " + ownerId, e);
+    }
   }
 
   @Override
   public @NonNull Page<NftMetadata> findAllNftTypes() {
-    throw new RuntimeException("Not implemented");
+    final String path = "/api/v1/tokens?type=NON_FUNGIBLE_UNIQUE";
+    final Function<JsonObject, List<Token>> dataExtractionFunction =
+        node -> jsonConverter.toTokens(node);
+    final Page<Token> tokens =
+        new RestBasedPage<>(restClient.getTarget(), dataExtractionFunction, path);
+    return new MappedPage<>(tokens, this::resolveNftMetadata);
   }
 
   @Override

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeClientNftMetadataTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeClientNftMetadataTest.java
@@ -1,0 +1,146 @@
+package org.hiero.microprofile.test;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.hiero.base.data.NftMetadata;
+import org.hiero.base.data.Page;
+import org.hiero.microprofile.implementation.MirrorNodeClientImpl;
+import org.hiero.microprofile.implementation.MirrorNodeJsonConverterImpl;
+import org.hiero.microprofile.implementation.MirrorNodeRestClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MirrorNodeClientNftMetadataTest {
+
+  private HttpServer server;
+
+  private MirrorNodeClientImpl client;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext("/api/v1/tokens", this::handleTokensRequest);
+    server.start();
+    final String baseUrl = "http://localhost:" + server.getAddress().getPort();
+    client =
+        new MirrorNodeClientImpl(
+            new MirrorNodeRestClientImpl(baseUrl), new MirrorNodeJsonConverterImpl());
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.stop(0);
+  }
+
+  @Test
+  void getNftMetadataReturnsNftTokenDetails() throws Exception {
+    final Optional<NftMetadata> result = client.getNftMetadata(TokenId.fromString("0.0.1001"));
+
+    Assertions.assertTrue(result.isPresent());
+    Assertions.assertEquals(TokenId.fromString("0.0.1001"), result.get().tokenId());
+    Assertions.assertEquals("Collection One", result.get().name());
+    Assertions.assertEquals("COL1", result.get().symbol());
+    Assertions.assertEquals(AccountId.fromString("0.0.5001"), result.get().treasuryAccountId());
+  }
+
+  @Test
+  void findAllNftTypesReturnsOnlyNftTypes() {
+    final Page<NftMetadata> page = client.findAllNftTypes();
+
+    Assertions.assertEquals(1, page.getData().size());
+    Assertions.assertEquals(TokenId.fromString("0.0.1001"), page.getData().getFirst().tokenId());
+    Assertions.assertFalse(page.hasNext());
+  }
+
+  @Test
+  void findNftTypesByOwnerFiltersOutFungibleTokens() {
+    final Page<NftMetadata> page = client.findNftTypesByOwner(AccountId.fromString("0.0.2002"));
+
+    Assertions.assertEquals(1, page.getData().size());
+    Assertions.assertEquals(TokenId.fromString("0.0.1002"), page.getData().getFirst().tokenId());
+    Assertions.assertEquals("Collection Two", page.getData().getFirst().name());
+  }
+
+  private void handleTokensRequest(final HttpExchange exchange) throws IOException {
+    final String path = exchange.getRequestURI().getPath();
+    final String query = exchange.getRequestURI().getQuery();
+
+    if ("/api/v1/tokens".equals(path)) {
+      if ("type=NON_FUNGIBLE_UNIQUE".equals(query)) {
+        respond(
+            exchange,
+            """
+            {"tokens":[{"token_id":"0.0.1001","metadata":"","name":"Collection One","symbol":"COL1","decimals":0,"type":"NON_FUNGIBLE_UNIQUE"}],"links":{"next":null}}
+            """);
+        return;
+      }
+      if ("account.id=0.0.2002".equals(query)) {
+        respond(
+            exchange,
+            """
+            {"tokens":[
+              {"token_id":"0.0.1002","metadata":"","name":"Collection Two","symbol":"COL2","decimals":0,"type":"NON_FUNGIBLE_UNIQUE"},
+              {"token_id":"0.0.2001","metadata":"","name":"Fungible Token","symbol":"FT","decimals":2,"type":"FUNGIBLE_COMMON"}
+            ],"links":{"next":null}}
+            """);
+        return;
+      }
+    }
+
+    if ("/api/v1/tokens/0.0.1001".equals(path)) {
+      respond(exchange, tokenInfoJson("0.0.1001", "Collection One", "COL1", "0.0.5001"));
+      return;
+    }
+
+    if ("/api/v1/tokens/0.0.1002".equals(path)) {
+      respond(exchange, tokenInfoJson("0.0.1002", "Collection Two", "COL2", "0.0.5002"));
+      return;
+    }
+
+    respond(exchange, "{}");
+  }
+
+  private static String tokenInfoJson(
+      final String tokenId, final String name, final String symbol, final String treasuryId) {
+    return """
+        {
+          "token_id":"%s",
+          "type":"NON_FUNGIBLE_UNIQUE",
+          "name":"%s",
+          "symbol":"%s",
+          "memo":"",
+          "decimals":"0",
+          "metadata":"",
+          "created_timestamp":"1",
+          "modified_timestamp":"2",
+          "expiry_timestamp":null,
+          "supply_type":"FINITE",
+          "initial_supply":"0",
+          "total_supply":"1",
+          "max_supply":"1000",
+          "treasury_account_id":"%s",
+          "deleted":false,
+          "custom_fees":{"fixed_fees":[],"fractional_fees":[],"royalty_fees":[]}
+        }
+        """
+        .formatted(tokenId, name, symbol, treasuryId);
+  }
+
+  private static void respond(final HttpExchange exchange, final String body) throws IOException {
+    final byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(200, bytes.length);
+    try (OutputStream outputStream = exchange.getResponseBody()) {
+      outputStream.write(bytes);
+    }
+  }
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
@@ -12,6 +12,7 @@ import org.hiero.base.HieroException;
 import org.hiero.base.data.Balance;
 import org.hiero.base.data.BalanceModification;
 import org.hiero.base.data.Block;
+import org.hiero.base.data.MappedPage;
 import org.hiero.base.data.Nft;
 import org.hiero.base.data.NftMetadata;
 import org.hiero.base.data.Page;
@@ -176,12 +177,23 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
 
   @Override
   public @NonNull Page<NftMetadata> findNftTypesByOwner(AccountId ownerId) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    Objects.requireNonNull(ownerId, "ownerId must not be null");
+    try {
+      return new MappedPage<>(queryTokensForAccount(ownerId), this::resolveNftMetadata);
+    } catch (final HieroException e) {
+      throw new IllegalStateException("Error querying NFT types for owner " + ownerId, e);
+    }
   }
 
   @Override
   public @NonNull Page<NftMetadata> findAllNftTypes() {
-    throw new UnsupportedOperationException("Not yet implemented");
+    final String path = "/api/v1/tokens?type=NON_FUNGIBLE_UNIQUE";
+    final Function<JsonNode, List<Token>> dataExtractionFunction =
+        node -> jsonConverter.toTokens(node);
+    final Page<Token> tokens =
+        new RestBasedPage<>(
+            objectMapper, restClient.mutate().clone(), path, dataExtractionFunction);
+    return new MappedPage<>(tokens, this::resolveNftMetadata);
   }
 
   @Override

--- a/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/MirrorNodeClientNftMetadataTest.java
+++ b/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/MirrorNodeClientNftMetadataTest.java
@@ -1,0 +1,143 @@
+package org.hiero.spring.test;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.hiero.base.data.NftMetadata;
+import org.hiero.base.data.Page;
+import org.hiero.spring.implementation.MirrorNodeClientImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+class MirrorNodeClientNftMetadataTest {
+
+  private HttpServer server;
+
+  private MirrorNodeClientImpl client;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext("/api/v1/tokens", this::handleTokensRequest);
+    server.start();
+    final String baseUrl = "http://localhost:" + server.getAddress().getPort();
+    client = new MirrorNodeClientImpl(RestClient.builder().baseUrl(baseUrl));
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.stop(0);
+  }
+
+  @Test
+  void getNftMetadataReturnsNftTokenDetails() throws Exception {
+    final Optional<NftMetadata> result = client.getNftMetadata(TokenId.fromString("0.0.1001"));
+
+    Assertions.assertTrue(result.isPresent());
+    Assertions.assertEquals(TokenId.fromString("0.0.1001"), result.get().tokenId());
+    Assertions.assertEquals("Collection One", result.get().name());
+    Assertions.assertEquals("COL1", result.get().symbol());
+    Assertions.assertEquals(AccountId.fromString("0.0.5001"), result.get().treasuryAccountId());
+  }
+
+  @Test
+  void findAllNftTypesReturnsOnlyNftTypes() {
+    final Page<NftMetadata> page = client.findAllNftTypes();
+
+    Assertions.assertEquals(1, page.getData().size());
+    Assertions.assertEquals(TokenId.fromString("0.0.1001"), page.getData().getFirst().tokenId());
+    Assertions.assertFalse(page.hasNext());
+  }
+
+  @Test
+  void findNftTypesByOwnerFiltersOutFungibleTokens() {
+    final Page<NftMetadata> page = client.findNftTypesByOwner(AccountId.fromString("0.0.2002"));
+
+    Assertions.assertEquals(1, page.getData().size());
+    Assertions.assertEquals(TokenId.fromString("0.0.1002"), page.getData().getFirst().tokenId());
+    Assertions.assertEquals("Collection Two", page.getData().getFirst().name());
+  }
+
+  private void handleTokensRequest(final HttpExchange exchange) throws IOException {
+    final String path = exchange.getRequestURI().getPath();
+    final String query = exchange.getRequestURI().getQuery();
+
+    if ("/api/v1/tokens".equals(path)) {
+      if ("type=NON_FUNGIBLE_UNIQUE".equals(query)) {
+        respond(
+            exchange,
+            """
+            {"tokens":[{"token_id":"0.0.1001","metadata":"","name":"Collection One","symbol":"COL1","decimals":0,"type":"NON_FUNGIBLE_UNIQUE"}],"links":{"next":null}}
+            """);
+        return;
+      }
+      if ("account.id=0.0.2002".equals(query)) {
+        respond(
+            exchange,
+            """
+            {"tokens":[
+              {"token_id":"0.0.1002","metadata":"","name":"Collection Two","symbol":"COL2","decimals":0,"type":"NON_FUNGIBLE_UNIQUE"},
+              {"token_id":"0.0.2001","metadata":"","name":"Fungible Token","symbol":"FT","decimals":2,"type":"FUNGIBLE_COMMON"}
+            ],"links":{"next":null}}
+            """);
+        return;
+      }
+    }
+
+    if ("/api/v1/tokens/0.0.1001".equals(path)) {
+      respond(exchange, tokenInfoJson("0.0.1001", "Collection One", "COL1", "0.0.5001"));
+      return;
+    }
+
+    if ("/api/v1/tokens/0.0.1002".equals(path)) {
+      respond(exchange, tokenInfoJson("0.0.1002", "Collection Two", "COL2", "0.0.5002"));
+      return;
+    }
+
+    respond(exchange, "{}");
+  }
+
+  private static String tokenInfoJson(
+      final String tokenId, final String name, final String symbol, final String treasuryId) {
+    return """
+        {
+          "token_id":"%s",
+          "type":"NON_FUNGIBLE_UNIQUE",
+          "name":"%s",
+          "symbol":"%s",
+          "memo":"",
+          "decimals":0,
+          "metadata":"",
+          "created_timestamp":1,
+          "modified_timestamp":2,
+          "expiry_timestamp":null,
+          "supply_type":"FINITE",
+          "initial_supply":"0",
+          "total_supply":"1",
+          "max_supply":"1000",
+          "treasury_account_id":"%s",
+          "deleted":false,
+          "custom_fees":{"fixed_fees":[],"fractional_fees":[],"royalty_fees":[]}
+        }
+        """
+        .formatted(tokenId, name, symbol, treasuryId);
+  }
+
+  private static void respond(final HttpExchange exchange, final String body) throws IOException {
+    final byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(200, bytes.length);
+    try (OutputStream outputStream = exchange.getResponseBody()) {
+      outputStream.write(bytes);
+    }
+  }
+}


### PR DESCRIPTION
## Description:

Implement the missing NFT Mirror Node metadata and type query support.

* Implement `getNftMetadata(TokenId)`
* Implement `findNftTypesByOwner(AccountId)` and `findAllNftTypes()` in Spring and MicroProfile
* Preserve pagination while mapping token pages to `NftMetadata`
* Add tests for the new query paths


## Related issue(s):

Fixes #149

## Notes for reviewer:

Validated with:
```bash
./mvnw -pl hiero-enterprise-base,hiero-enterprise-spring,hiero-enterprise-microprofile -am test -Dtest=MirrorNodeClientNftMetadataTest -Dsurefire.failIfNoSpecifiedTests=false
./mvnw spotless:check
```

## Checklist

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
