### PR TITLE
feat: add Spring Boot Actuator health indicators for Mirror Node and Operator Balance

### DIFF
--- a/hiero-enterprise-spring/pom.xml
+++ b/hiero-enterprise-spring/pom.xml
@@ -49,6 +49,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>hiero-enterprise-test</artifactId>
       <scope>test</scope>

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -53,7 +53,7 @@ import org.springframework.web.context.annotation.ApplicationScope;
 
 @AutoConfiguration
 @EnableConfigurationProperties({HieroProperties.class, HieroNetworkProperties.class})
-@Import({MicrometerSupportConfig.class})
+@Import({MicrometerSupportConfig.class, HieroHealthAutoConfiguration.class})
 public class HieroAutoConfiguration {
 
   private static final Logger log = LoggerFactory.getLogger(HieroAutoConfiguration.class);

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroHealthAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroHealthAutoConfiguration.java
@@ -1,0 +1,42 @@
+package org.hiero.spring.implementation;
+
+import org.hiero.base.AccountClient;
+import org.hiero.base.mirrornode.MirrorNodeClient;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for Hiero health indicators.
+ */
+@AutoConfiguration
+@ConditionalOnClass(HealthIndicator.class)
+@ConditionalOnProperty(
+    prefix = "spring.hiero.health",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class HieroHealthAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnProperty(
+      prefix = "spring.hiero",
+      name = "mirrorNodeSupported",
+      havingValue = "true",
+      matchIfMissing = true)
+  public MirrorNodeHealthIndicator mirrorNodeHealthIndicator(final MirrorNodeClient mirrorNodeClient) {
+    return new MirrorNodeHealthIndicator(mirrorNodeClient);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public OperatorBalanceHealthIndicator operatorBalanceHealthIndicator(
+      final AccountClient accountClient, final HieroProperties properties) {
+    return new OperatorBalanceHealthIndicator(
+        accountClient, properties.getHealth().getMinBalanceInHbar());
+  }
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroHealthProperties.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroHealthProperties.java
@@ -1,0 +1,33 @@
+package org.hiero.spring.implementation;
+
+/**
+ * Configuration properties for Hiero health indicators.
+ */
+public class HieroHealthProperties {
+
+  /**
+   * Whether to enable Hiero health indicators.
+   */
+  private boolean enabled = true;
+
+  /**
+   * Minimum balance for the operator account (in Hbar) before reporting a warning/error.
+   */
+  private long minBalanceInHbar = 10;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public long getMinBalanceInHbar() {
+    return minBalanceInHbar;
+  }
+
+  public void setMinBalanceInHbar(long minBalanceInHbar) {
+    this.minBalanceInHbar = minBalanceInHbar;
+  }
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroProperties.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroProperties.java
@@ -15,6 +15,9 @@ public class HieroProperties {
   @NestedConfigurationProperty
   private HieroNetworkProperties network = new HieroNetworkProperties();
 
+  @NestedConfigurationProperty
+  private HieroHealthProperties health = new HieroHealthProperties();
+
   public String getAccountId() {
     return this.accountId;
   }
@@ -37,5 +40,13 @@ public class HieroProperties {
 
   public void setNetwork(HieroNetworkProperties network) {
     this.network = network;
+  }
+
+  public HieroHealthProperties getHealth() {
+    return health;
+  }
+
+  public void setHealth(HieroHealthProperties health) {
+    this.health = health;
   }
 }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeHealthIndicator.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeHealthIndicator.java
@@ -1,0 +1,33 @@
+package org.hiero.spring.implementation;
+
+import org.hiero.base.mirrornode.MirrorNodeClient;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+/**
+ * Health indicator for the Hiero Mirror Node.
+ */
+public class MirrorNodeHealthIndicator implements HealthIndicator {
+
+  private final MirrorNodeClient mirrorNodeClient;
+
+  public MirrorNodeHealthIndicator(final MirrorNodeClient mirrorNodeClient) {
+    this.mirrorNodeClient = mirrorNodeClient;
+  }
+
+  @Override
+  public Health health() {
+    try {
+      // Perform a simple query to verify connectivity
+      mirrorNodeClient.queryBlocks();
+      return Health.up()
+          .withDetail("status", "Mirror Node is reachable")
+          .build();
+    } catch (Exception e) {
+      return Health.down()
+          .withDetail("error", "Mirror Node is unreachable")
+          .withDetail("reason", e.getMessage())
+          .build();
+    }
+  }
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeHealthIndicator.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeHealthIndicator.java
@@ -25,7 +25,7 @@ public class MirrorNodeHealthIndicator implements HealthIndicator {
           .build();
     } catch (Exception e) {
       return Health.down()
-          .withDetail("error", "Mirror Node is unreachable")
+          .withDetail("status", "Mirror Node is unreachable")
           .withDetail("reason", e.getMessage())
           .build();
     }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/OperatorBalanceHealthIndicator.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/OperatorBalanceHealthIndicator.java
@@ -1,0 +1,47 @@
+package org.hiero.spring.implementation;
+
+import com.hedera.hashgraph.sdk.Hbar;
+import org.hiero.base.AccountClient;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+/**
+ * Health indicator for the Hiero operator account balance.
+ */
+public class OperatorBalanceHealthIndicator implements HealthIndicator {
+
+  private final AccountClient accountClient;
+  private final long minBalanceInHbar;
+
+  public OperatorBalanceHealthIndicator(
+      final AccountClient accountClient, final long minBalanceInHbar) {
+    this.accountClient = accountClient;
+    this.minBalanceInHbar = minBalanceInHbar;
+  }
+
+  @Override
+  public Health health() {
+    try {
+      final Hbar balance = accountClient.getOperatorAccountBalance();
+      final long currentTinybars = balance.toTinybars();
+      final long thresholdTinybars = minBalanceInHbar * 100_000_000L;
+
+      Health.Builder builder = Health.up()
+          .withDetail("balance", balance.toString())
+          .withDetail("thresholdHbar", minBalanceInHbar);
+
+      if (currentTinybars < thresholdTinybars) {
+        return builder.down()
+            .withDetail("status", "Low balance warning")
+            .build();
+      }
+
+      return builder.withDetail("status", "Balance is sufficient").build();
+    } catch (Exception e) {
+      return Health.down()
+          .withDetail("error", "Could not retrieve operator balance")
+          .withDetail("reason", e.getMessage())
+          .build();
+    }
+  }
+}

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/OperatorBalanceHealthIndicator.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/OperatorBalanceHealthIndicator.java
@@ -39,7 +39,7 @@ public class OperatorBalanceHealthIndicator implements HealthIndicator {
       return builder.withDetail("status", "Balance is sufficient").build();
     } catch (Exception e) {
       return Health.down()
-          .withDetail("error", "Could not retrieve operator balance")
+          .withDetail("status", "Could not retrieve operator balance")
           .withDetail("reason", e.getMessage())
           .build();
     }

--- a/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/HealthIndicatorTest.java
+++ b/hiero-enterprise-spring/src/test/java/org/hiero/spring/test/HealthIndicatorTest.java
@@ -1,0 +1,73 @@
+package org.hiero.spring.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hashgraph.sdk.Hbar;
+import org.hiero.base.AccountClient;
+import org.hiero.base.mirrornode.MirrorNodeClient;
+import org.hiero.spring.implementation.MirrorNodeHealthIndicator;
+import org.hiero.spring.implementation.OperatorBalanceHealthIndicator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+/**
+ * Unit tests for Hiero health indicators.
+ */
+@ExtendWith(MockitoExtension.class)
+class HealthIndicatorTest {
+
+  @Mock
+  private MirrorNodeClient mirrorNodeClient;
+
+  @Mock
+  private AccountClient accountClient;
+
+  @Test
+  void testMirrorNodeHealthUp() throws Exception {
+    MirrorNodeHealthIndicator indicator = new MirrorNodeHealthIndicator(mirrorNodeClient);
+    Health health = indicator.health();
+    assertEquals(Status.UP, health.getStatus());
+    assertEquals("Mirror Node is reachable", health.getDetails().get("status"));
+  }
+
+  @Test
+  void testMirrorNodeHealthDown() throws Exception {
+    when(mirrorNodeClient.queryBlocks()).thenThrow(new RuntimeException("Connection failed"));
+    MirrorNodeHealthIndicator indicator = new MirrorNodeHealthIndicator(mirrorNodeClient);
+    Health health = indicator.health();
+    assertEquals(Status.DOWN, health.getStatus());
+    assertEquals("Mirror Node is unreachable", health.getDetails().get("status"));
+  }
+
+  @Test
+  void testOperatorBalanceHealthUp() throws Exception {
+    when(accountClient.getOperatorAccountBalance()).thenReturn(Hbar.from(20));
+    OperatorBalanceHealthIndicator indicator = new OperatorBalanceHealthIndicator(accountClient, 10);
+    Health health = indicator.health();
+    assertEquals(Status.UP, health.getStatus());
+    assertEquals("Balance is sufficient", health.getDetails().get("status"));
+  }
+
+  @Test
+  void testOperatorBalanceHealthDown() throws Exception {
+    when(accountClient.getOperatorAccountBalance()).thenReturn(Hbar.from(5));
+    OperatorBalanceHealthIndicator indicator = new OperatorBalanceHealthIndicator(accountClient, 10);
+    Health health = indicator.health();
+    assertEquals(Status.DOWN, health.getStatus());
+    assertEquals("Low balance warning", health.getDetails().get("status"));
+  }
+
+  @Test
+  void testOperatorBalanceHealthError() throws Exception {
+    when(accountClient.getOperatorAccountBalance()).thenThrow(new RuntimeException("API error"));
+    OperatorBalanceHealthIndicator indicator = new OperatorBalanceHealthIndicator(accountClient, 10);
+    Health health = indicator.health();
+    assertEquals(Status.DOWN, health.getStatus());
+    assertEquals("Could not retrieve operator balance", health.getDetails().get("status"));
+  }
+}


### PR DESCRIPTION
This pr is solve #146 

## Description

This PR adds Spring Boot Actuator health indicators to improve the observability of Hiero-based Spring applications and introduces basic health indicators so applications can expose this information through the standard Actuator health endpoint.

While working with the Spring integration, I noticed there was no built-in way to monitor important runtime dependencies such as:

- Mirror Node connectivity
- operator account balance health

## Changes Included
### MirrorNodeHealthIndicator

Adds a lightweight connectivity check for the configured Mirror Node REST API to verify that it is reachable and responding correctly.

### OperatorBalanceHealthIndicator

Checks the configured operator account balance and compares it against a configurable minimum threshold. If the balance becomes too low, the health details will expose a warning so teams can detect the issue earlier before transactions begin failing.

### Configuration Support

Added configuration properties under:
```
spring.hiero.health.enabled=true
spring.hiero.health.min-balance-in-hbar=10
```

### Auto Configuration

Introduced HieroHealthAutoConfiguration so the health indicators are automatically registered when Spring Boot Actuator is available on the classpath.

### Dependency Update

Added spring-boot-starter-actuator as an optional dependency in the hiero-enterprise-spring module.

### Verification

Verified successfully with:

```bash
./mvnw clean compile
```

Also verified the auto-configuration registration through HieroAutoConfiguration.

## Edit: 

## Testing & Verification

To make sure the new health indicators behave correctly in different scenarios, I also added a dedicated unit test suite: `HealthIndicatorTest.java`

## Test Coverage

The tests currently cover:

- successful health checks when the Mirror Node is reachable and the operator balance is healthy
- connectivity failure scenarios by mocking network/API exceptions
- low balance threshold handling
- failures while fetching account balance information

I also standardized the health detail response keys across both indicators during testing so the JSON output remains more consistent for monitoring tools and dashboards.

Verified successfully with:

```
./mvnw test -pl hiero-enterprise-spring -Dtest=HealthIndicatorTest
```
All tests are passing successfully.

Please review this pr @Ndacyayisenga-droid and I’d really appreciate feedback on the approach.
