### PR TITLE
docs: add architecture and setup guides

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,71 @@
 # Architecture
 
-<!-- TODO: Add high-level architecture (modules, dependencies, layering, interaction with Hiero/Hedera SDK and mirror node). -->
+Hiero Enterprise Java is split into three main modules:
 
-Placeholder: technical documentation for the architecture of Hiero Enterprise Java will be added here.
+- `hiero-enterprise-base` contains the shared core APIs and implementations.
+- `hiero-enterprise-spring` integrates the base module with Spring Boot.
+- `hiero-enterprise-microprofile` integrates the base module with Eclipse MicroProfile implementations such as Quarkus.
+
+## Module roles
+
+### Base module
+
+The base module contains the core service contracts and their shared implementations. This includes:
+
+- protocol-layer clients for submitting transactions
+- mirror-node clients and repositories for query use cases
+- shared data models such as accounts, tokens, NFTs, topics, contracts, and pages
+- configuration abstractions such as `HieroConfig` and `HieroContext`
+
+This module is the foundation used by both framework integrations.
+
+### Spring Boot module
+
+The Spring Boot module provides:
+
+- the `@EnableHiero` annotation
+- Spring Boot configuration properties under `spring.hiero.*`
+- Spring-managed beans for the managed services defined in the base module
+- Spring-specific mirror-node REST and JSON converter implementations
+
+Applications using Spring Boot depend on this module instead of wiring the base services manually.
+
+### MicroProfile module
+
+The MicroProfile module provides:
+
+- CDI producers for the managed services
+- MicroProfile configuration classes under `hiero.*`
+- MicroProfile-specific mirror-node REST and JSON converter implementations
+
+Applications using MicroProfile or Quarkus can inject the same service interfaces that are available in the base module.
+
+## Main layers
+
+The project is organized around two main interaction paths:
+
+1. Protocol-layer access for transactions and network operations
+2. Mirror-node access for read-only queries
+
+In practice, applications typically work with high-level clients and repositories instead of using the lower-level SDK directly.
+
+## Interaction flow
+
+At a high level, the flow looks like this:
+
+1. Framework-specific configuration creates a `HieroConfig`
+2. `HieroConfig` creates a `HieroContext`
+3. The framework module exposes managed clients and repositories
+4. Transaction use cases go through the protocol-layer client
+5. Query use cases go through the mirror-node client and repositories
+
+## External dependencies
+
+The project currently builds on top of the Hedera Java SDK and is being migrated to the Hiero namespace over time. Mirror-node queries are handled through REST-based clients exposed by the framework modules.
+
+## Where to continue
+
+- See [Getting Started](getting-started.md) for basic setup.
+- See [Spring Boot](spring-boot.md) for Spring configuration and usage.
+- See [MicroProfile](microprofile.md) for CDI and MicroProfile configuration.
+- See [Base / Managed Services](managed-services.md) for the main services exposed to applications.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,69 @@
 # Getting Started
 
-<!-- TODO: Add getting started content (dependencies, minimal setup, network configuration). -->
+This guide shows the basic setup needed to use Hiero Enterprise Java in an application.
 
-Placeholder: technical documentation for getting started with Hiero Enterprise Java will be added here.
+## Choose an integration module
+
+Use one of the framework modules depending on your application:
+
+- `hiero-enterprise-spring` for Spring Boot
+- `hiero-enterprise-microprofile` for MicroProfile or Quarkus
+
+The base module provides the shared APIs and implementations, but most applications should start with one of the framework integrations.
+
+## Spring Boot dependency
+
+```xml
+<dependency>
+    <groupId>org.hiero</groupId>
+    <artifactId>hiero-enterprise-spring</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+## MicroProfile dependency
+
+```xml
+<dependency>
+    <groupId>org.hiero</groupId>
+    <artifactId>hiero-enterprise-microprofile</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+## Required configuration
+
+In both integrations, you need to configure:
+
+- an operator account ID
+- the private key for that operator account
+- the target network or custom node settings
+
+The project currently supports DER-encoded ECDSA private keys for the operator configuration.
+
+## Common setup steps
+
+1. Add the dependency for your framework
+2. Configure the operator account and network
+3. Enable or produce the Hiero services
+4. Inject a managed client such as `AccountClient`, `FileClient`, or `SmartContractClient`
+
+## Network choices
+
+You can use one of the predefined Hedera-based networks or provide custom nodes and a mirror node endpoint. This is useful for local or custom environments such as Solo-based setups.
+
+## Running the build
+
+The project uses Maven and includes the Maven wrapper:
+
+```bash
+./mvnw verify
+```
+
+Some tests require real network credentials. If no account is configured, those tests will fail.
+
+## Next steps
+
+- See [Spring Boot](spring-boot.md) for Spring-specific setup.
+- See [MicroProfile](microprofile.md) for MicroProfile-specific setup.
+- See [Base / Managed Services](managed-services.md) for the available clients and repositories.

--- a/docs/managed-services.md
+++ b/docs/managed-services.md
@@ -1,5 +1,60 @@
 # Base / Managed Services
 
-<!-- TODO: Add documentation for hiero-enterprise-base: HieroContext, AccountClient, FileClient, FungibleTokenClient, NftClient, SmartContractClient, ContractVerificationClient, mirror node repositories, ProtocolLayerClient, MirrorNodeClient. -->
+The base module defines the main service interfaces used by both the Spring Boot and MicroProfile integrations.
 
-Placeholder: technical documentation for the base module and managed services will be added here.
+## Core configuration objects
+
+- `HieroConfig` creates framework-independent configuration
+- `HieroContext` holds the active network and operator account information
+
+These objects are used internally by the framework integrations and shared implementations.
+
+## Transaction-oriented clients
+
+The following managed clients are used for write or transaction-based operations:
+
+- `AccountClient`
+- `FileClient`
+- `FungibleTokenClient`
+- `NftClient`
+- `SmartContractClient`
+- `TopicClient`
+- `HookClient`
+
+These clients build on the protocol-layer support in the base module.
+
+## Contract verification
+
+- `ContractVerificationClient` provides smart-contract verification support
+
+## Mirror-node access
+
+The base module also exposes a lower-level `MirrorNodeClient` plus repository-style abstractions for query use cases.
+
+Available repository interfaces include:
+
+- `AccountRepository`
+- `BlockRepository`
+- `ContractRepository`
+- `NetworkRepository`
+- `NftRepository`
+- `TokenRepository`
+- `TopicRepository`
+- `TransactionRepository`
+
+These repositories are intended for read-only access to data exposed through the mirror node.
+
+## Protocol-layer access
+
+- `ProtocolLayerClient` provides lower-level access for transaction submission and related protocol operations
+
+Most applications should prefer the higher-level managed clients unless they need a lower-level integration point.
+
+## Framework availability
+
+The services in this module are exposed through:
+
+- Spring beans in `hiero-enterprise-spring`
+- CDI producers in `hiero-enterprise-microprofile`
+
+That means application code can usually depend on the shared interfaces while letting the framework module provide the implementation.

--- a/docs/microprofile.md
+++ b/docs/microprofile.md
@@ -1,5 +1,73 @@
 # MicroProfile Integration
 
-<!-- TODO: Add MicroProfile/Quarkus setup, configuration, available clients and usage. -->
+The `hiero-enterprise-microprofile` module provides CDI-based integration for Eclipse MicroProfile runtimes such as Quarkus.
 
-Placeholder: technical documentation for the MicroProfile integration (hiero-enterprise-microprofile) will be added here.
+## Dependency
+
+```xml
+<dependency>
+    <groupId>org.hiero</groupId>
+    <artifactId>hiero-enterprise-microprofile</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+## Configuration
+
+The MicroProfile integration reads configuration from the `hiero.*` namespace.
+
+Example:
+
+```properties
+hiero.accountId=0.0.53854625
+hiero.privateKey=YOUR_DER_ENCODED_PRIVATE_KEY
+hiero.network.name=hedera-testnet
+```
+
+Additional network-related settings include:
+
+- `hiero.network.nodes`
+- `hiero.network.mirrornode`
+- `hiero.network.requestTimeoutInMs`
+
+When `hiero.network.nodes` is provided, the named network setting is not used.
+
+## Managed services
+
+The module uses CDI producers to expose the same service interfaces defined in the base module.
+
+Examples include:
+
+- `AccountClient`
+- `FileClient`
+- `FungibleTokenClient`
+- `NftClient`
+- `SmartContractClient`
+- `TopicClient`
+- `MirrorNodeClient`
+- repository interfaces such as `AccountRepository`, `TokenRepository`, and `NftRepository`
+
+## Injection example
+
+```java
+@ApplicationScoped
+public class HieroAccountService {
+
+    @Inject
+    AccountClient accountClient;
+}
+```
+
+## What the module provides
+
+The MicroProfile module wires:
+
+- configuration objects for operator and network settings
+- a shared `HieroConfig` and `HieroContext`
+- CDI-produced protocol-layer clients
+- CDI-produced mirror-node clients and repositories
+- MicroProfile-specific REST and JSON converter implementations
+
+## Sample application
+
+See the MicroProfile sample module in the repository for a minimal example using this integration.

--- a/docs/spring-boot.md
+++ b/docs/spring-boot.md
@@ -1,5 +1,86 @@
 # Spring Boot Integration
 
-<!-- TODO: Add Spring Boot setup, @EnableHiero, configuration properties, available clients and usage. -->
+The `hiero-enterprise-spring` module provides Spring Boot integration for the managed Hiero services.
 
-Placeholder: technical documentation for the Spring Boot integration (hiero-enterprise-spring) will be added here.
+## Dependency
+
+```xml
+<dependency>
+    <groupId>org.hiero</groupId>
+    <artifactId>hiero-enterprise-spring</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+## Enable Hiero support
+
+Add `@EnableHiero` to your Spring Boot application:
+
+```java
+import org.hiero.spring.EnableHiero;
+
+@SpringBootApplication
+@EnableHiero
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}
+```
+
+## Configuration
+
+The Spring integration uses properties under `spring.hiero.*`.
+
+Example:
+
+```properties
+spring.hiero.accountId=0.0.53854625
+spring.hiero.privateKey=YOUR_DER_ENCODED_PRIVATE_KEY
+spring.hiero.network.name=hedera-testnet
+```
+
+Important properties:
+
+- `spring.hiero.accountId`
+- `spring.hiero.privateKey`
+- `spring.hiero.network.name`
+- `spring.hiero.network.mirrorNode`
+- `spring.hiero.network.requestTimeoutInMs`
+
+You can also provide custom nodes through `spring.hiero.network.nodes`. When custom nodes are provided, the named network is ignored.
+
+## Using managed services
+
+Once Hiero support is enabled, the main services can be injected as Spring beans.
+
+Example:
+
+```java
+@Service
+public class HieroFileService {
+
+    private final FileClient fileClient;
+
+    public HieroFileService(FileClient fileClient) {
+        this.fileClient = fileClient;
+    }
+
+    public String readFile(FileId fileId) {
+        return new String(fileClient.readFile(fileId));
+    }
+}
+```
+
+## What the module provides
+
+The Spring module wires:
+
+- the Hiero configuration and context
+- protocol-layer clients
+- mirror-node clients and repositories
+- Spring-specific REST and JSON converter implementations
+
+## Sample application
+
+See the Spring sample module in the repository for a minimal example application using this integration.


### PR DESCRIPTION
## Description:

Add documentation for the main architecture and setup topics.

* Replace placeholder content in `docs/architecture.md`
* Replace placeholder content in `docs/getting-started.md`
* Add Spring Boot setup and usage documentation in `docs/spring-boot.md`
* Add MicroProfile setup and usage documentation in `docs/microprofile.md`
* Add an overview of the base module and managed services in `docs/managed-services.md`

## Related issue(s):

Fixes #151


## Checklist

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
