### PR TITLE
feat: add testcontainers support for hiero environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,59 @@ spring.hiero.privateKey=2130020100312346052b8104400304220420c236508c429395a8180b
 
 Currently there is no running release process and we work on setting uop everything to do releases under the hiero-ledger org.
 
+## Integration Testing with Testcontainers
+
+The project provides a dedicated module `hiero-enterprise-testcontainers` for simplified integration testing using [Testcontainers](https://testcontainers.com/). This allows you to spin up a local Hiero network (including Mirror Node) automatically during your tests.
+
+### Usage
+
+Add the following dependency to your project:
+
+```xml
+<dependency>
+    <groupId>org.hiero</groupId>
+    <artifactId>hiero-enterprise-testcontainers</artifactId>
+    <version>VERSION</version>
+    <scope>test</scope>
+</dependency>
+```
+
+### Spring Boot Integration
+
+You can use `@DynamicPropertySource` to automatically configure your Spring Boot application to use the temporary container:
+
+```java
+@Testcontainers
+@SpringBootTest
+class MyIntegrationTest {
+
+    @Container
+    static HieroContainer hiero = new HieroContainer();
+
+    @DynamicPropertySource
+    static void hieroProperties(DynamicPropertyRegistry registry) {
+        HieroTestcontainers.registerProperties(registry, hiero);
+    }
+
+    @Test
+    void testSomething() {
+        // Your test logic here
+    }
+}
+```
+
+### Manual Configuration
+
+If you are not using Spring Boot, you can still use the containers manually:
+
+```java
+HieroContainer hiero = new HieroContainer();
+hiero.start();
+
+String consensusEndpoint = hiero.getConsensusEndpoint();
+String mirrorEndpoint = hiero.getMirrorRestEndpoint();
+```
+
 ## Documentation
 
 Technical documentation (getting started, architecture, Spring/MicroProfile, managed services, ADRs) is in the **[docs](docs/)** folder and is published as [GitHub Pages](https://hiero-ledger.github.io/hiero-enterprise-java/).

--- a/hiero-enterprise-testcontainers/pom.xml
+++ b/hiero-enterprise-testcontainers/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hiero</groupId>
+    <artifactId>hiero-enterprise</artifactId>
+    <version>0.20.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>hiero-enterprise-testcontainers</artifactId>
+
+  <name>Hiero Enterprise Testcontainers</name>
+  <description>Testcontainers support for Hiero</description>
+  <url>https://github.com/hiero-ledger/hiero-enterprise-java</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>hiero-enterprise-base</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>

--- a/hiero-enterprise-testcontainers/src/main/java/org/hiero/testcontainers/HieroContainer.java
+++ b/hiero-enterprise-testcontainers/src/main/java/org/hiero/testcontainers/HieroContainer.java
@@ -1,0 +1,93 @@
+package org.hiero.testcontainers;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/** Testcontainers implementation for Hiero (Hedera) Local Node. */
+public class HieroContainer extends GenericContainer<HieroContainer> {
+
+  public static final String DEFAULT_IMAGE_NAME = "hashgraph/hedera-local-node";
+  public static final String DEFAULT_TAG = "latest";
+
+  private static final int CONSENSUS_GRPC_PORT = 50211;
+  private static final int MIRROR_NODE_REST_PORT = 5551;
+  private static final int MIRROR_NODE_GRPC_PORT = 5600;
+
+  public HieroContainer() {
+    this(DockerImageName.parse(DEFAULT_IMAGE_NAME).withTag(DEFAULT_TAG));
+  }
+
+  public HieroContainer(String image) {
+    this(DockerImageName.parse(image));
+  }
+
+  public HieroContainer(DockerImageName dockerImageName) {
+    super(dockerImageName);
+    withExposedPorts(CONSENSUS_GRPC_PORT, MIRROR_NODE_REST_PORT, MIRROR_NODE_GRPC_PORT);
+    waitingFor(Wait.forHttp("/health").forPort(MIRROR_NODE_REST_PORT));
+  }
+
+  /**
+   * Returns the consensus node IP address.
+   *
+   * @return the IP address
+   */
+  public String getConsensusIp() {
+    return getHost();
+  }
+
+  /**
+   * Returns the consensus node port.
+   *
+   * @return the port
+   */
+  public int getConsensusPort() {
+    return getMappedPort(CONSENSUS_GRPC_PORT);
+  }
+
+  /**
+   * Returns the consensus node account ID. Default for local node is usually 0.0.3.
+   *
+   * @return the account ID
+   */
+  public String getConsensusAccount() {
+    return "0.0.3";
+  }
+
+  /**
+   * Returns the mirror node REST endpoint.
+   *
+   * @return the REST endpoint URL
+   */
+  public String getMirrorRestEndpoint() {
+    return "http://" + getHost() + ":" + getMappedPort(MIRROR_NODE_REST_PORT);
+  }
+
+  /**
+   * Returns the mirror node gRPC endpoint.
+   *
+   * @return the gRPC endpoint (host:port)
+   */
+  public String getMirrorGrpcEndpoint() {
+    return getHost() + ":" + getMappedPort(MIRROR_NODE_GRPC_PORT);
+  }
+
+  /**
+   * Returns the default operator account ID for local node.
+   *
+   * @return the operator account ID
+   */
+  public String getOperatorId() {
+    return "0.0.2";
+  }
+
+  /**
+   * Returns the default operator private key for local node.
+   *
+   * @return the operator private key
+   */
+  public String getOperatorKey() {
+    return "302e020100300506032b65700422042091132178e72057a1d7528025956fe30b0b847f8cdd2fab28edc77343657bc4c4";
+  }
+}

--- a/hiero-enterprise-testcontainers/src/main/java/org/hiero/testcontainers/HieroTestcontainers.java
+++ b/hiero-enterprise-testcontainers/src/main/java/org/hiero/testcontainers/HieroTestcontainers.java
@@ -1,0 +1,38 @@
+package org.hiero.testcontainers;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+
+/** Utility class to assist with Spring Boot integration for Hiero Testcontainers. */
+public final class HieroTestcontainers {
+
+  private HieroTestcontainers() {}
+
+  /**
+   * Registers the necessary properties for a HieroContainer in the given DynamicPropertyRegistry.
+   * This allows Spring Boot applications to automatically connect to the container.
+   *
+   * @param registry the DynamicPropertyRegistry to register properties with
+   * @param container the HieroContainer instance
+   */
+  public static void registerProperties(
+      DynamicPropertyRegistry registry, HieroContainer container) {
+    registry.add("spring.hiero.network.nodes[0].ip", container::getConsensusIp);
+    registry.add("spring.hiero.network.nodes[0].port", container::getConsensusPort);
+    registry.add("spring.hiero.network.nodes[0].account", container::getConsensusAccount);
+    registry.add("spring.hiero.network.mirror-node", container::getMirrorRestEndpoint);
+    registry.add("spring.hiero.accountId", container::getOperatorId);
+    registry.add("spring.hiero.privateKey", container::getOperatorKey);
+  }
+
+  /**
+   * Registers the necessary properties for a MirrorNodeContainer in the given
+   * DynamicPropertyRegistry.
+   *
+   * @param registry the DynamicPropertyRegistry to register properties with
+   * @param container the MirrorNodeContainer instance
+   */
+  public static void registerMirrorNodeProperties(
+      DynamicPropertyRegistry registry, MirrorNodeContainer container) {
+    registry.add("spring.hiero.network.mirror-node", container::getRestEndpoint);
+  }
+}

--- a/hiero-enterprise-testcontainers/src/main/java/org/hiero/testcontainers/MirrorNodeContainer.java
+++ b/hiero-enterprise-testcontainers/src/main/java/org/hiero/testcontainers/MirrorNodeContainer.java
@@ -1,0 +1,51 @@
+package org.hiero.testcontainers;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Testcontainers implementation for Hiero Mirror Node. This container provides Mirror Node REST and
+ * gRPC services. Note: This implementation currently uses the hedera-local-node image as it
+ * provides a pre-configured mirror node environment.
+ */
+public class MirrorNodeContainer extends GenericContainer<MirrorNodeContainer> {
+
+  public static final String DEFAULT_IMAGE_NAME = "hashgraph/hedera-local-node";
+  public static final String DEFAULT_TAG = "latest";
+
+  private static final int REST_PORT = 5551;
+  private static final int GRPC_PORT = 5600;
+
+  public MirrorNodeContainer() {
+    this(DockerImageName.parse(DEFAULT_IMAGE_NAME).withTag(DEFAULT_TAG));
+  }
+
+  public MirrorNodeContainer(String image) {
+    this(DockerImageName.parse(image));
+  }
+
+  public MirrorNodeContainer(DockerImageName dockerImageName) {
+    super(dockerImageName);
+    withExposedPorts(REST_PORT, GRPC_PORT);
+    waitingFor(Wait.forHttp("/health").forPort(REST_PORT));
+  }
+
+  /**
+   * Returns the mirror node REST endpoint.
+   *
+   * @return the REST endpoint URL
+   */
+  public String getRestEndpoint() {
+    return "http://" + getHost() + ":" + getMappedPort(REST_PORT);
+  }
+
+  /**
+   * Returns the mirror node gRPC endpoint.
+   *
+   * @return the gRPC endpoint (host:port)
+   */
+  public String getGrpcEndpoint() {
+    return getHost() + ":" + getMappedPort(GRPC_PORT);
+  }
+}

--- a/hiero-enterprise-testcontainers/src/test/java/org/hiero/testcontainers/HieroContainerTest.java
+++ b/hiero-enterprise-testcontainers/src/test/java/org/hiero/testcontainers/HieroContainerTest.java
@@ -1,0 +1,24 @@
+package org.hiero.testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class HieroContainerTest {
+
+  @Test
+  void testContainerDefaults() {
+    HieroContainer container = new HieroContainer();
+    assertEquals("hashgraph/hedera-local-node:latest", container.getDockerImageName());
+    assertEquals("0.0.3", container.getConsensusAccount());
+    assertEquals("0.0.2", container.getOperatorId());
+    assertNotNull(container.getOperatorKey());
+  }
+
+  @Test
+  void testMirrorNodeContainerDefaults() {
+    MirrorNodeContainer container = new MirrorNodeContainer();
+    assertEquals("hashgraph/hedera-local-node:latest", container.getDockerImageName());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
     <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
+    <testcontainers.version>1.20.4</testcontainers.version>
   </properties>
 
   <dependencyManagement>
@@ -109,6 +110,18 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>hiero-enterprise-microprofile</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>hiero-enterprise-testcontainers</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.hedera.hashgraph</groupId>
@@ -214,6 +227,7 @@
     <module>hiero-enterprise-test</module>
     <module>hiero-enterprise-spring</module>
     <module>hiero-enterprise-microprofile</module>
+    <module>hiero-enterprise-testcontainers</module>
     <module>hiero-enterprise-spring-sample</module>
     <module>hiero-enterprise-microprofile-sample</module>
   </modules>


### PR DESCRIPTION
This pr is resolve the issue #154 

## Description

This PR introduces a new module, `hiero-enterprise-testcontainers`, to simplify integration testing for applications using hiero-enterprise-java.

While exploring integration testing, I noticed that running tests currently depends on either a manually configured local setup or access to external test networks. This PR aims to make the testing experience more isolated, reproducible, and easier to run locally or in CI environments.

## Changes Included

- `HieroContainer`: Added a Testcontainers wrapper around the local Hiero node Docker image. The container automatically starts the environment and exposes the required endpoints for: consensus gRPC, Mirror Node REST and Mirror Node gRPC

- `MirrorNodeContainer`: Added support for running Mirror Node services separately so repository and historical query flows can also be tested in isolation.

- Spring Boot Integration: Added a small utility helper for Spring Boot integration using `@DynamicPropertySource`, making it easier for applications to automatically connect to the temporary container environment during tests.

Example usage:

```
@Testcontainers
@SpringBootTest
class MyIntegrationTest {

    @Container
    static HieroContainer hiero = new HieroContainer();

    @DynamicPropertySource
    static void hieroProperties(DynamicPropertyRegistry registry) {
        HieroTestcontainers.registerProperties(registry, hiero);
    }
}
```

## Why This Could Help

This makes integration testing much easier for contributors and downstream applications since tests can run without requiring a persistent local setup or external testnet access.

Some benefits include:

* easier contributor onboarding
* more reproducible integration tests
* cleaner CI/CD execution
* isolated test environments
* reduced dependency on external infrastructure

## Verification

Verified successfully with:

```bash id="gjl4u0"
./mvnw clean compile -pl hiero-enterprise-testcontainers -am
```

Also added unit tests for the default container configuration and applied the project formatting/style rules using Spotless.

@Ndacyayisenga-droid please review this pr and i am open for your feedback.
