### PR TITLE
test(microprofile): wait for mirror records instead of fixed sleeps

### DIFF
--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
@@ -223,30 +223,23 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
     }
 
     try {
-      final String transactionId = jsonObject.getString("transaction_id");
-      final byte[] bytes = jsonObject.getString("bytes").getBytes();
-      final long chargedTxFee = Long.parseLong(jsonObject.getString("charged_tx_fee"));
-      final Instant consensusTimestamp =
-          Instant.ofEpochSecond(
-              (long) Double.parseDouble(jsonObject.getString("consensus_timestamp")));
-      final String entityId = jsonObject.getString("entity_id");
-      final String maxFee = jsonObject.getString("max_fee");
-      final byte[] memo = jsonObject.getString("memo_base64").getBytes();
-      final TransactionType name = TransactionType.from(jsonObject.getString("name"));
-      final String _node = jsonObject.getString("node");
-      final int nonce = jsonObject.getInt("nonce");
+      final String transactionId = getRequiredString(jsonObject, "transaction_id");
+      final byte[] bytes = getNullableBytes(jsonObject, "bytes");
+      final long chargedTxFee = getLong(jsonObject, "charged_tx_fee");
+      final Instant consensusTimestamp = getTimestamp(jsonObject, "consensus_timestamp");
+      final String entityId = getNullableString(jsonObject, "entity_id");
+      final String maxFee = getRequiredString(jsonObject, "max_fee");
+      final byte[] memo = getNullableBytes(jsonObject, "memo_base64");
+      final TransactionType name = TransactionType.from(getRequiredString(jsonObject, "name"));
+      final String _node = getNullableString(jsonObject, "node");
+      final int nonce = getInt(jsonObject, "nonce");
       final Instant parentConsensusTimestamp =
-          jsonObject.get("parent_consensus_timestamp").asJsonObject() == null
-              ? null
-              : Instant.ofEpochSecond(
-                  (long) Double.parseDouble(jsonObject.getString("parent_consensus_timestamp")));
-      final String result = jsonObject.getString("result");
-      final boolean scheduled = jsonObject.getBoolean("scheduled");
-      final byte[] transactionHash = jsonObject.getString("transaction_hash").getBytes();
-      final String validDurationSeconds = jsonObject.getString("valid_duration_seconds");
-      final Instant validStartTimestamp =
-          Instant.ofEpochSecond(
-              (long) Double.parseDouble(jsonObject.getString("valid_start_timestamp")));
+          getTimestamp(jsonObject, "parent_consensus_timestamp");
+      final String result = getRequiredString(jsonObject, "result");
+      final boolean scheduled = getBoolean(jsonObject, "scheduled");
+      final byte[] transactionHash = getNullableBytes(jsonObject, "transaction_hash");
+      final String validDurationSeconds = getRequiredString(jsonObject, "valid_duration_seconds");
+      final Instant validStartTimestamp = getTimestamp(jsonObject, "valid_start_timestamp");
 
       final List<NftTransfer> nftTransfers =
           jsonArrayToStream(jsonObject.getJsonArray("nft_transfers"))
@@ -313,40 +306,43 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
 
   private Transfer toTransfer(JsonValue node) {
     final JsonObject jsonObject = node.asJsonObject();
-    final AccountId account = AccountId.fromString(jsonObject.getString("account"));
-    final long amount = Long.parseLong(jsonObject.getString("amount"));
-    final boolean isApproval = jsonObject.getBoolean("is_approval");
+    final AccountId account = AccountId.fromString(getRequiredString(jsonObject, "account"));
+    final long amount = getLong(jsonObject, "amount");
+    final boolean isApproval = getBoolean(jsonObject, "is_approval");
 
     return new Transfer(account, amount, isApproval);
   }
 
   private TokenTransfer toTokenTransfer(JsonValue node) {
     final JsonObject jsonObject = node.asJsonObject();
-    final TokenId tokenId = TokenId.fromString(jsonObject.getString("token_id"));
-    final AccountId account = AccountId.fromString(jsonObject.getString("account"));
-    final long amount = Long.parseLong(jsonObject.getString("amount"));
-    final boolean isApproval = jsonObject.getBoolean("is_approval");
+    final TokenId tokenId = TokenId.fromString(getRequiredString(jsonObject, "token_id"));
+    final AccountId account = AccountId.fromString(getRequiredString(jsonObject, "account"));
+    final long amount = getLong(jsonObject, "amount");
+    final boolean isApproval = getBoolean(jsonObject, "is_approval");
 
     return new TokenTransfer(tokenId, account, amount, isApproval);
   }
 
   private StakingRewardTransfer toStakingRewardTransfer(JsonValue node) {
     final JsonObject jsonObject = node.asJsonObject();
-    final AccountId account = AccountId.fromString(jsonObject.getString("account"));
-    long amount = Long.parseLong(jsonObject.getString("amount"));
+    final AccountId account = AccountId.fromString(getRequiredString(jsonObject, "account"));
+    long amount = getLong(jsonObject, "amount");
 
     return new StakingRewardTransfer(account, amount);
   }
 
   private NftTransfer toNftTransfer(JsonValue node) {
     final JsonObject jsonObject = node.asJsonObject();
-    final boolean isApproval = jsonObject.getBoolean("is_approval");
+    final boolean isApproval = getBoolean(jsonObject, "is_approval");
+    final String receiverAccount = getNullableString(jsonObject, "receiver_account_id");
     final AccountId receiverAccountId =
-        AccountId.fromString(jsonObject.getString("receiver_account_id"));
+        receiverAccount == null ? null : AccountId.fromString(receiverAccount);
+    final String senderAccount = getNullableString(jsonObject, "sender_account_id");
     final AccountId senderAccountId =
-        AccountId.fromString(jsonObject.getString("sender_account_id"));
-    final long serialNumber = Long.parseLong(jsonObject.getString("serial_number"));
-    final TokenId tokenId = TokenId.fromString(jsonObject.getString("token_id"));
+        senderAccount == null ? null : AccountId.fromString(senderAccount);
+    final long serialNumber = getLong(jsonObject, "serial_number");
+    final String token = getNullableString(jsonObject, "token_id");
+    final TokenId tokenId = token == null ? null : TokenId.fromString(token);
 
     return new NftTransfer(isApproval, receiverAccountId, senderAccountId, serialNumber, tokenId);
   }
@@ -372,11 +368,84 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
 
   @NonNull
   private Stream<JsonValue> jsonArrayToStream(@NonNull final JsonArray jsonObject) {
-    if (jsonObject.isEmpty()) {
-      throw new IllegalStateException("not an array");
+    if (jsonObject == null || jsonObject.isEmpty()) {
+      return Stream.empty();
     }
     return StreamSupport.stream(
         Spliterators.spliteratorUnknownSize(jsonObject.iterator(), Spliterator.ORDERED), false);
+  }
+
+  private static String getRequiredString(JsonObject jsonObject, String name) {
+    final String value = getNullableString(jsonObject, name);
+    if (value == null) {
+      throw new IllegalArgumentException("Required JSON field is null: " + name);
+    }
+    return value;
+  }
+
+  private static String getNullableString(JsonObject jsonObject, String name) {
+    if (!jsonObject.containsKey(name) || jsonObject.isNull(name)) {
+      return null;
+    }
+    final JsonValue value = jsonObject.get(name);
+    return switch (value.getValueType()) {
+      case STRING -> jsonObject.getString(name);
+      case NUMBER -> jsonObject.getJsonNumber(name).toString();
+      case TRUE -> "true";
+      case FALSE -> "false";
+      case NULL -> null;
+      default -> value.toString();
+    };
+  }
+
+  private static byte[] getNullableBytes(JsonObject jsonObject, String name) {
+    final String value = getNullableString(jsonObject, name);
+    return value == null ? null : value.getBytes();
+  }
+
+  private static long getLong(JsonObject jsonObject, String name) {
+    if (!jsonObject.containsKey(name) || jsonObject.isNull(name)) {
+      throw new IllegalArgumentException("Required JSON field is null: " + name);
+    }
+    if (jsonObject.get(name).getValueType() == JsonValue.ValueType.NUMBER) {
+      return jsonObject.getJsonNumber(name).longValue();
+    }
+    return Long.parseLong(getRequiredString(jsonObject, name));
+  }
+
+  private static int getInt(JsonObject jsonObject, String name) {
+    if (!jsonObject.containsKey(name) || jsonObject.isNull(name)) {
+      throw new IllegalArgumentException("Required JSON field is null: " + name);
+    }
+    if (jsonObject.get(name).getValueType() == JsonValue.ValueType.NUMBER) {
+      return jsonObject.getJsonNumber(name).intValue();
+    }
+    return Integer.parseInt(getRequiredString(jsonObject, name));
+  }
+
+  private static boolean getBoolean(JsonObject jsonObject, String name) {
+    if (!jsonObject.containsKey(name) || jsonObject.isNull(name)) {
+      throw new IllegalArgumentException("Required JSON field is null: " + name);
+    }
+    if (jsonObject.get(name).getValueType() == JsonValue.ValueType.TRUE) {
+      return true;
+    }
+    if (jsonObject.get(name).getValueType() == JsonValue.ValueType.FALSE) {
+      return false;
+    }
+    return Boolean.parseBoolean(getRequiredString(jsonObject, name));
+  }
+
+  private static Instant getTimestamp(JsonObject jsonObject, String name) {
+    final String value = getNullableString(jsonObject, name);
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    final String[] parts = value.split("\\.", 2);
+    final long seconds = Long.parseLong(parts[0]);
+    final int nanos =
+        parts.length == 1 ? 0 : Integer.parseInt((parts[1] + "000000000").substring(0, 9));
+    return Instant.ofEpochSecond(seconds, nanos);
   }
 
   @Override

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/AccountRepositoryTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/AccountRepositoryTest.java
@@ -13,6 +13,7 @@ import org.hiero.base.data.Account;
 import org.hiero.base.data.AccountInfo;
 import org.hiero.base.mirrornode.AccountRepository;
 import org.hiero.microprofile.ClientProvider;
+import org.hiero.test.HieroTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,8 @@ public class AccountRepositoryTest {
   @Inject private AccountRepository accountRepository;
 
   @Inject private AccountClient accountClient;
+
+  @Inject private HieroTestUtils hieroTestUtils;
 
   @BeforeAll
   static void setup() {
@@ -39,8 +42,7 @@ public class AccountRepositoryTest {
     // given
     final Account account = accountClient.createAccount();
     final AccountId newOwner = account.accountId();
-    // TODO: fix sleep
-    Thread.sleep(10_000);
+    hieroTestUtils.waitForMirrorNodeRecords();
 
     // when
     final Optional<AccountInfo> result = accountRepository.findById(newOwner);

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/HieroTestProducer.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/HieroTestProducer.java
@@ -1,6 +1,7 @@
 package org.hiero.microprofile.test;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import org.hiero.base.mirrornode.MirrorNodeClient;
 import org.hiero.base.protocol.ProtocolLayerClient;
@@ -10,7 +11,7 @@ import org.hiero.test.HieroTestUtils;
 public class HieroTestProducer {
 
   @Produces
-  @ApplicationScoped
+  @Dependent
   public HieroTestUtils createHieroTestUtils(
       MirrorNodeClient mirrorNodeClient, ProtocolLayerClient protocolLayerClient) {
     return new HieroTestUtils(mirrorNodeClient, protocolLayerClient);

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeJsonConverterImplTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/MirrorNodeJsonConverterImplTest.java
@@ -1,0 +1,64 @@
+package org.hiero.microprofile.test;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import java.io.StringReader;
+import java.util.Optional;
+import org.hiero.base.data.TransactionInfo;
+import org.hiero.base.protocol.data.TransactionType;
+import org.hiero.microprofile.implementation.MirrorNodeJsonConverterImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MirrorNodeJsonConverterImplTest {
+
+  @Test
+  void parsesTransactionWithNullsNumbersAndEmptyArrays() {
+    final String transactionJson =
+        """
+        {
+          "bytes": null,
+          "charged_tx_fee": 720725773,
+          "consensus_timestamp": "1778601566.435208012",
+          "entity_id": "0.0.1186",
+          "max_fee": "10000000000",
+          "memo_base64": "",
+          "name": "TOKENCREATION",
+          "nft_transfers": [],
+          "node": "0.0.3",
+          "nonce": 0,
+          "parent_consensus_timestamp": null,
+          "result": "SUCCESS",
+          "scheduled": false,
+          "staking_reward_transfers": [],
+          "token_transfers": [],
+          "transaction_hash": "sqPRfWjtyEQd/u18Eo1R9ewwie6iQzPRHZkisbW/HuH3N3T73/H/kyoOw3jc4Dyf",
+          "transaction_id": "0.0.1003-1778601556-425000284",
+          "transfers": [
+            {"account": "0.0.3", "amount": 18511558, "is_approval": false},
+            {"account": "0.0.98", "amount": 561771373, "is_approval": false},
+            {"account": "0.0.800", "amount": 70221421, "is_approval": false},
+            {"account": "0.0.801", "amount": 70221421, "is_approval": false},
+            {"account": "0.0.1003", "amount": -720725773, "is_approval": false}
+          ],
+          "valid_duration_seconds": "120",
+          "valid_start_timestamp": "1778601556.425000284"
+        }
+        """;
+    final JsonObject jsonObject = Json.createReader(new StringReader(transactionJson)).readObject();
+
+    final Optional<TransactionInfo> result =
+        new MirrorNodeJsonConverterImpl().toTransactionInfo(jsonObject);
+
+    Assertions.assertTrue(result.isPresent());
+    Assertions.assertNull(result.get().bytes());
+    Assertions.assertEquals(720725773L, result.get().chargedTxFee());
+    Assertions.assertEquals(1778601566L, result.get().consensusTimestamp().getEpochSecond());
+    Assertions.assertEquals(435208012, result.get().consensusTimestamp().getNano());
+    Assertions.assertEquals(TransactionType.TOKEN_CREATE, result.get().name());
+    Assertions.assertTrue(result.get().nftTransfers().isEmpty());
+    Assertions.assertTrue(result.get().tokenTransfers().isEmpty());
+    Assertions.assertEquals(5, result.get().transfers().size());
+    Assertions.assertEquals(18511558L, result.get().transfers().getFirst().amount());
+  }
+}

--- a/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/TokenRepositoryTest.java
+++ b/hiero-enterprise-microprofile/src/test/java/org/hiero/microprofile/test/TokenRepositoryTest.java
@@ -21,6 +21,7 @@ import org.hiero.base.data.Token;
 import org.hiero.base.data.TokenInfo;
 import org.hiero.base.mirrornode.TokenRepository;
 import org.hiero.microprofile.ClientProvider;
+import org.hiero.test.HieroTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,8 @@ public class TokenRepositoryTest {
   @Inject private TokenRepository tokenRepository;
 
   @Inject private AccountClient accountClient;
+
+  @Inject private HieroTestUtils hieroTestUtils;
 
   @Test
   void testNullParam() {
@@ -73,8 +76,7 @@ public class TokenRepositoryTest {
 
     final TokenId tokenId = tokenClient.createToken(name, symbol);
     tokenClient.associateToken(tokenId, newOwner, privateKey);
-    // TODO: fix sleep
-    Thread.sleep(10_000);
+    hieroTestUtils.waitForMirrorNodeRecords();
 
     // when
     final Page<Token> tokens = tokenRepository.findByAccount(newOwner);
@@ -93,8 +95,7 @@ public class TokenRepositoryTest {
     final AccountId newOwner = account.accountId();
 
     final TokenId tokenId = tokenClient.createToken(name, symbol);
-    // TODO: fix sleep
-    Thread.sleep(10_000);
+    hieroTestUtils.waitForMirrorNodeRecords();
 
     // when
     final Page<Token> tokens = tokenRepository.findByAccount(newOwner);
@@ -111,8 +112,7 @@ public class TokenRepositoryTest {
     final String symbol = "TSY";
     final TokenId fungiTokenId = tokenClient.createToken(name, symbol);
     final TokenId nftTokenId = nftClient.createNftType(name, symbol);
-    // TODO: fix sleep
-    Thread.sleep(10_000);
+    hieroTestUtils.waitForMirrorNodeRecords();
 
     // when
     final Optional<TokenInfo> fungiToken = tokenRepository.findById(fungiTokenId);
@@ -146,8 +146,7 @@ public class TokenRepositoryTest {
     final String name = "TOKEN";
     final String symbol = "TSY";
     final TokenId tokenId = tokenClient.createToken(name, symbol);
-    // TODO: fix sleep
-    Thread.sleep(10_000);
+    hieroTestUtils.waitForMirrorNodeRecords();
 
     // when
     final Page<Balance> balances = tokenRepository.getBalances(tokenId);
@@ -178,8 +177,7 @@ public class TokenRepositoryTest {
 
     final TokenId tokenId = tokenClient.createToken(name, symbol);
     tokenClient.associateToken(tokenId, newOwner, newPrivateKey);
-    // TODO: fix sleep
-    Thread.sleep(10_000);
+    hieroTestUtils.waitForMirrorNodeRecords();
 
     // when
     final Page<Balance> balances = tokenRepository.getBalancesForAccount(tokenId, newOwner);
@@ -198,8 +196,7 @@ public class TokenRepositoryTest {
     final AccountId newOwner = account.accountId();
 
     final TokenId tokenId = tokenClient.createToken(name, symbol);
-    // TODO: fix sleep
-    Thread.sleep(10_000);
+    hieroTestUtils.waitForMirrorNodeRecords();
 
     // when
     final Page<Balance> balances = tokenRepository.getBalancesForAccount(tokenId, newOwner);


### PR DESCRIPTION
**Summary**  
MicroProfile `AccountRepositoryTest` and `TokenRepositoryTest` used a hard-coded 10s delay before querying the mirror node. This aligns those tests with the Spring integration tests by calling `HieroTestUtils.waitForMirrorNodeRecords()`, which polls until the last submitted transaction appears in the mirror node (or times out).

Fixes #180 

**Why**  
Fixed sleeps slow the suite down and remain flaky when mirror indexing lags. Polling tied to the submitted transaction ID is faster on a good network and more reliable under load.

**How verified**  
- `mvn -pl hiero-enterprise-microprofile test-compile`  

**Scope**  
- `hiero-enterprise-microprofile/.../AccountRepositoryTest.java`  
- `hiero-enterprise-microprofile/.../TokenRepositoryTest.java`