### PR TITLE
feat: implement distributed tracing with OpenTelemetry

### DIFF
--- a/hiero-enterprise-base/pom.xml
+++ b/hiero-enterprise-base/pom.xml
@@ -47,6 +47,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/hiero-enterprise-base/src/main/java/module-info.java
+++ b/hiero-enterprise-base/src/main/java/module-info.java
@@ -27,4 +27,6 @@ module org.hiero.base {
   requires com.google.protobuf; // TODO: We should not have the need to use it
   requires static org.jspecify;
   requires com.google.auto.service;
+  requires io.opentelemetry.api;
+  requires io.opentelemetry.context;
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
@@ -24,8 +24,21 @@ import org.hiero.base.data.TopicMessage;
 import org.hiero.base.data.TransactionInfo;
 import org.hiero.base.mirrornode.MirrorNodeClient;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
 
 public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient {
+
+  protected final Tracer tracer;
+
+  protected AbstractMirrorNodeClient() {
+    this(null);
+  }
+
+  protected AbstractMirrorNodeClient(@Nullable final Tracer tracer) {
+    this.tracer = tracer != null ? tracer : TracerProvider.noop().get("org.hiero.enterprise");
+  }
 
   @NonNull
   protected abstract MirrorNodeRestClient<JSON> getRestClient();
@@ -38,6 +51,7 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
       @NonNull final TokenId tokenId, final long serialNumber) throws HieroException {
     final JSON json =
         TracingSupport.withinSpanWithHieroException(
+            tracer,
             "hiero.mirrornode.queryNftsByTokenIdAndSerial",
             () -> getRestClient().queryNftsByTokenIdAndSerial(tokenId, serialNumber));
     return getJsonConverter().toNft(json);
@@ -49,6 +63,7 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
     Objects.requireNonNull(accountId, "accountId must not be null");
     final JSON json =
         TracingSupport.withinSpanWithHieroException(
+            tracer,
             "hiero.mirrornode.queryAccount", () -> getRestClient().queryAccount(accountId));
     return getJsonConverter().toAccountInfo(json);
   }
@@ -89,6 +104,7 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
       throws HieroException {
     final JSON json =
         TracingSupport.withinSpanWithHieroException(
+            tracer,
             "hiero.mirrornode.queryTransaction",
             () -> getRestClient().queryTransaction(transactionId));
     return getJsonConverter().toTransactionInfo(json);

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
@@ -36,7 +36,10 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
   @Override
   public @NonNull final Optional<Nft> queryNftsByTokenIdAndSerial(
       @NonNull final TokenId tokenId, final long serialNumber) throws HieroException {
-    final JSON json = getRestClient().queryNftsByTokenIdAndSerial(tokenId, serialNumber);
+    final JSON json =
+        TracingSupport.withinSpanWithHieroException(
+            "hiero.mirrornode.queryNftsByTokenIdAndSerial",
+            () -> getRestClient().queryNftsByTokenIdAndSerial(tokenId, serialNumber));
     return getJsonConverter().toNft(json);
   }
 
@@ -44,7 +47,9 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
   public @NonNull final Optional<AccountInfo> queryAccount(@NonNull final AccountId accountId)
       throws HieroException {
     Objects.requireNonNull(accountId, "accountId must not be null");
-    final JSON json = getRestClient().queryAccount(accountId);
+    final JSON json =
+        TracingSupport.withinSpanWithHieroException(
+            "hiero.mirrornode.queryAccount", () -> getRestClient().queryAccount(accountId));
     return getJsonConverter().toAccountInfo(json);
   }
 
@@ -82,7 +87,10 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
   @NonNull
   public final Optional<TransactionInfo> queryTransaction(@NonNull String transactionId)
       throws HieroException {
-    final JSON json = getRestClient().queryTransaction(transactionId);
+    final JSON json =
+        TracingSupport.withinSpanWithHieroException(
+            "hiero.mirrornode.queryTransaction",
+            () -> getRestClient().queryTransaction(transactionId));
     return getJsonConverter().toTransactionInfo(json);
   }
 

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ProtocolLayerClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ProtocolLayerClientImpl.java
@@ -45,6 +45,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
 import org.hiero.base.HieroContext;
 import org.hiero.base.HieroException;
 import org.hiero.base.data.Account;
@@ -106,6 +108,7 @@ import org.hiero.base.protocol.data.TopicUpdateRequest;
 import org.hiero.base.protocol.data.TopicUpdateResult;
 import org.hiero.base.protocol.data.TransactionType;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,11 +122,19 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
 
   private final HieroContext hieroContext;
 
+  private final Tracer tracer;
+
   private final AtomicReference<ReceiveRecordInterceptor> recordInterceptor =
       new AtomicReference<>(ReceiveRecordInterceptor.DEFAULT_INTERCEPTOR);
 
   public ProtocolLayerClientImpl(@NonNull final HieroContext hieroContext) {
+    this(hieroContext, null);
+  }
+
+  public ProtocolLayerClientImpl(
+      @NonNull final HieroContext hieroContext, @Nullable final Tracer tracer) {
     this.hieroContext = Objects.requireNonNull(hieroContext, "hieroContext must not be null");
+    this.tracer = tracer != null ? tracer : TracerProvider.noop().get("org.hiero.enterprise");
     listeners = new CopyOnWriteArrayList<>();
   }
 
@@ -729,6 +740,7 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
     Objects.requireNonNull(type, "type must not be null");
     try {
       return TracingSupport.withinSpanWithHieroException(
+          tracer,
           "hiero.transaction." + type.name().toLowerCase(),
           () -> {
             Span.current().setAttribute("hiero.transaction.type", type.name());
@@ -805,6 +817,7 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
     Objects.requireNonNull(query, "query must not be null");
     try {
       return TracingSupport.withinSpanWithHieroException(
+          tracer,
           "hiero.query." + query.getClass().getSimpleName().toLowerCase(),
           () -> {
             Span.current().setAttribute("hiero.query.type", query.getClass().getSimpleName());

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ProtocolLayerClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ProtocolLayerClientImpl.java
@@ -44,10 +44,12 @@ import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import io.opentelemetry.api.trace.Span;
 import org.hiero.base.HieroContext;
 import org.hiero.base.HieroException;
 import org.hiero.base.data.Account;
 import org.hiero.base.data.ContractParam;
+import org.hiero.base.implementation.TracingSupport;
 import org.hiero.base.interceptors.ReceiveRecordInterceptor;
 import org.hiero.base.interceptors.ReceiveRecordInterceptor.ReceiveRecordHandler;
 import org.hiero.base.protocol.ProtocolLayerClient;
@@ -726,42 +728,50 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
     Objects.requireNonNull(transaction, "transaction must not be null");
     Objects.requireNonNull(type, "type must not be null");
     try {
-      log.debug("Sending transaction of type {}", transaction.getClass().getSimpleName());
-      final TransactionResponse response = transaction.execute(hieroContext.getClient());
-      listeners.forEach(
-          listener -> {
+      return TracingSupport.withinSpanWithHieroException(
+          "hiero.transaction." + type.name().toLowerCase(),
+          () -> {
+            Span.current().setAttribute("hiero.transaction.type", type.name());
+            log.debug("Sending transaction of type {}", transaction.getClass().getSimpleName());
+            final TransactionResponse response = transaction.execute(hieroContext.getClient());
+            Span.current().setAttribute("hiero.transaction.id", response.transactionId.toString());
+            listeners.forEach(
+                listener -> {
+                  try {
+                    listener.transactionSubmitted(type, response.transactionId);
+                  } catch (Exception e) {
+                    log.error("Failed to notify listener", e);
+                  }
+                });
             try {
-              listener.transactionSubmitted(type, response.transactionId);
+              log.debug(
+                  "Waiting for receipt of transaction '{}' of type {}",
+                  response.transactionId,
+                  transaction.getClass().getSimpleName());
+              final TransactionReceipt receipt = response.getReceipt(hieroContext.getClient());
+              Span.current().setAttribute("hiero.status.code", receipt.status.toString());
+              listeners.forEach(
+                  listener -> {
+                    try {
+                      listener.transactionHandled(type, response.transactionId, receipt.status);
+                    } catch (Exception e) {
+                      log.error("Failed to notify listener", e);
+                    }
+                  });
+              return receipt;
             } catch (Exception e) {
-              log.error("Failed to notify listener", e);
+              throw new HieroException(
+                  "Failed to receive receipt of transaction '"
+                      + response.transactionId
+                      + "' of type "
+                      + transaction.getClass(),
+                  e);
             }
           });
-      try {
-        log.debug(
-            "Waiting for receipt of transaction '{}' of type {}",
-            response.transactionId,
-            transaction.getClass().getSimpleName());
-        final TransactionReceipt receipt = response.getReceipt(hieroContext.getClient());
-        listeners.forEach(
-            listener -> {
-              try {
-                listener.transactionHandled(type, response.transactionId, receipt.status);
-              } catch (Exception e) {
-                log.error("Failed to notify listener", e);
-              }
-            });
-        return receipt;
-      } catch (Exception e) {
-        throw new HieroException(
-            "Failed to receive receipt of transaction '"
-                + response.transactionId
-                + "' of type "
-                + transaction.getClass(),
-            e);
-      }
+    } catch (final HieroException e) {
+      throw e;
     } catch (final Exception e) {
-      throw new HieroException(
-          "Failed to execute transaction of type " + transaction.getClass().getSimpleName(), e);
+      throw new HieroException("Unexpected error during transaction execution", e);
     }
   }
 
@@ -794,10 +804,17 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
       throws HieroException {
     Objects.requireNonNull(query, "query must not be null");
     try {
-      log.debug("Sending query of type {}", query.getClass().getSimpleName());
-      return query.execute(hieroContext.getClient());
-    } catch (Exception e) {
-      throw new HieroException("Failed to execute query", e);
+      return TracingSupport.withinSpanWithHieroException(
+          "hiero.query." + query.getClass().getSimpleName().toLowerCase(),
+          () -> {
+            Span.current().setAttribute("hiero.query.type", query.getClass().getSimpleName());
+            log.debug("Sending query of type {}", query.getClass().getSimpleName());
+            return query.execute(hieroContext.getClient());
+          });
+    } catch (final HieroException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new HieroException("Unexpected error during query execution", e);
     }
   }
 

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TracingSupport.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TracingSupport.java
@@ -29,18 +29,23 @@ public final class TracingSupport {
   /**
    * Execute a supplier within a new span.
    *
+   * @param tracer the tracer to use
    * @param spanName the name of the span
    * @param supplier the supplier to execute
    * @param <T> the type of the result
    * @return the result
    */
-  public static <T> T withinSpan(@NonNull final String spanName, @NonNull final Supplier<T> supplier) {
-    return withinSpan(spanName, null, supplier);
+  public static <T> T withinSpan(
+      @NonNull final Tracer tracer,
+      @NonNull final String spanName,
+      @NonNull final Supplier<T> supplier) {
+    return withinSpan(tracer, spanName, null, supplier);
   }
 
   /**
    * Execute a supplier within a new span with custom attributes.
    *
+   * @param tracer the tracer to use
    * @param spanName the name of the span
    * @param attributesConfigurer a configurer for the span attributes
    * @param supplier the supplier to execute
@@ -48,10 +53,11 @@ public final class TracingSupport {
    * @return the result
    */
   public static <T> T withinSpan(
+      @NonNull final Tracer tracer,
       @NonNull final String spanName,
       @Nullable final SpanAttributesConfigurer attributesConfigurer,
       @NonNull final Supplier<T> supplier) {
-    final SpanBuilder spanBuilder = getTracer().spanBuilder(spanName);
+    final SpanBuilder spanBuilder = tracer.spanBuilder(spanName);
     if (attributesConfigurer != null) {
       attributesConfigurer.configure(spanBuilder);
     }
@@ -69,6 +75,7 @@ public final class TracingSupport {
   /**
    * Execute an operation that may throw a HieroException within a new span.
    *
+   * @param tracer the tracer to use
    * @param spanName the name of the span
    * @param operation the operation to execute
    * @param <T> the type of the result
@@ -76,9 +83,11 @@ public final class TracingSupport {
    * @throws HieroException if the operation fails
    */
   public static <T> T withinSpanWithHieroException(
-      @NonNull final String spanName, @NonNull final HieroOperation<T> operation)
+      @NonNull final Tracer tracer,
+      @NonNull final String spanName,
+      @NonNull final HieroOperation<T> operation)
       throws HieroException {
-    final Span span = getTracer().spanBuilder(spanName).startSpan();
+    final Span span = tracer.spanBuilder(spanName).startSpan();
     try (var ignored = span.makeCurrent()) {
       return operation.execute();
     } catch (final HieroException e) {

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TracingSupport.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/TracingSupport.java
@@ -1,0 +1,109 @@
+package org.hiero.base.implementation;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import java.util.function.Supplier;
+import org.hiero.base.HieroException;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/** Utility class for OpenTelemetry tracing. */
+public final class TracingSupport {
+
+  private static final String INSTRUMENTATION_NAME = "org.hiero.enterprise";
+
+  private TracingSupport() {}
+
+  /**
+   * Get the tracer for the Hiero library.
+   *
+   * @return the tracer
+   */
+  @NonNull
+  public static Tracer getTracer() {
+    return GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
+  }
+
+  /**
+   * Execute a supplier within a new span.
+   *
+   * @param spanName the name of the span
+   * @param supplier the supplier to execute
+   * @param <T> the type of the result
+   * @return the result
+   */
+  public static <T> T withinSpan(@NonNull final String spanName, @NonNull final Supplier<T> supplier) {
+    return withinSpan(spanName, null, supplier);
+  }
+
+  /**
+   * Execute a supplier within a new span with custom attributes.
+   *
+   * @param spanName the name of the span
+   * @param attributesConfigurer a configurer for the span attributes
+   * @param supplier the supplier to execute
+   * @param <T> the type of the result
+   * @return the result
+   */
+  public static <T> T withinSpan(
+      @NonNull final String spanName,
+      @Nullable final SpanAttributesConfigurer attributesConfigurer,
+      @NonNull final Supplier<T> supplier) {
+    final SpanBuilder spanBuilder = getTracer().spanBuilder(spanName);
+    if (attributesConfigurer != null) {
+      attributesConfigurer.configure(spanBuilder);
+    }
+    final Span span = spanBuilder.startSpan();
+    try (var ignored = span.makeCurrent()) {
+      return supplier.get();
+    } catch (final Exception e) {
+      span.recordException(e);
+      throw e;
+    } finally {
+      span.end();
+    }
+  }
+
+  /**
+   * Execute an operation that may throw a HieroException within a new span.
+   *
+   * @param spanName the name of the span
+   * @param operation the operation to execute
+   * @param <T> the type of the result
+   * @return the result
+   * @throws HieroException if the operation fails
+   */
+  public static <T> T withinSpanWithHieroException(
+      @NonNull final String spanName, @NonNull final HieroOperation<T> operation)
+      throws HieroException {
+    final Span span = getTracer().spanBuilder(spanName).startSpan();
+    try (var ignored = span.makeCurrent()) {
+      return operation.execute();
+    } catch (final HieroException e) {
+      span.recordException(e);
+      throw e;
+    } catch (final Exception e) {
+      span.recordException(e);
+      if (e instanceof RuntimeException) {
+        throw (RuntimeException) e;
+      }
+      throw new HieroException("Error during traced operation", e);
+    } finally {
+      span.end();
+    }
+  }
+
+  /** Interface for Hiero operations that can throw any exception. */
+  @FunctionalInterface
+  public interface HieroOperation<T> {
+    T execute() throws Exception;
+  }
+
+  /** Interface to configure span attributes. */
+  @FunctionalInterface
+  public interface SpanAttributesConfigurer {
+    void configure(@NonNull SpanBuilder spanBuilder);
+  }
+}

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
@@ -53,6 +53,8 @@ public class ClientProvider {
 
   @Inject @ConfigProperties private HieroNetworkConfiguration networkConfiguration;
 
+  @Inject private jakarta.enterprise.inject.Instance<io.opentelemetry.api.trace.Tracer> tracerInstance;
+
   @NonNull
   @Produces
   @ApplicationScoped
@@ -71,7 +73,8 @@ public class ClientProvider {
   @Produces
   @ApplicationScoped
   ProtocolLayerClient createProtocolLayerClient(@NonNull final HieroContext hieroContext) {
-    return new ProtocolLayerClientImpl(hieroContext);
+    io.opentelemetry.api.trace.Tracer tracer = tracerInstance.isResolvable() ? tracerInstance.get() : null;
+    return new ProtocolLayerClientImpl(hieroContext, tracer);
   }
 
   @NonNull
@@ -149,7 +152,8 @@ public class ClientProvider {
             .orElseThrow(() -> new IllegalStateException("No mirror node addresses configured"));
     final MirrorNodeRestClientImpl restClient = new MirrorNodeRestClientImpl(target);
     final MirrorNodeJsonConverterImpl jsonConverter = new MirrorNodeJsonConverterImpl();
-    return new MirrorNodeClientImpl(restClient, jsonConverter);
+    io.opentelemetry.api.trace.Tracer tracer = tracerInstance.isResolvable() ? tracerInstance.get() : null;
+    return new MirrorNodeClientImpl(restClient, jsonConverter, tracer);
   }
 
   @NonNull

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeClientImpl.java
@@ -23,6 +23,8 @@ import org.hiero.base.implementation.MirrorNodeJsonConverter;
 import org.hiero.base.implementation.MirrorNodeRestClient;
 import org.hiero.base.protocol.data.TransactionType;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import io.opentelemetry.api.trace.Tracer;
 
 public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
@@ -32,6 +34,14 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonObject> {
 
   public MirrorNodeClientImpl(
       MirrorNodeRestClientImpl restClient, MirrorNodeJsonConverter<JsonObject> jsonConverter) {
+    this(restClient, jsonConverter, null);
+  }
+
+  public MirrorNodeClientImpl(
+      MirrorNodeRestClientImpl restClient,
+      MirrorNodeJsonConverter<JsonObject> jsonConverter,
+      @Nullable Tracer tracer) {
+    super(tracer);
     this.restClient = Objects.requireNonNull(restClient, "restClient must not be null");
     this.jsonConverter = Objects.requireNonNull(jsonConverter, "jsonConverter must not be null");
   }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -73,8 +73,10 @@ public class HieroAutoConfiguration {
   @Bean
   ProtocolLayerClient protocolLevelClient(
       final HieroContext hieroContext,
-      @Autowired(required = false) final ReceiveRecordInterceptor interceptor) {
-    ProtocolLayerClientImpl protocolLayerClient = new ProtocolLayerClientImpl(hieroContext);
+      @Autowired(required = false) final ReceiveRecordInterceptor interceptor,
+      final org.springframework.beans.factory.ObjectProvider<io.opentelemetry.api.trace.Tracer> tracerProvider) {
+    ProtocolLayerClientImpl protocolLayerClient =
+        new ProtocolLayerClientImpl(hieroContext, tracerProvider.getIfAvailable());
     if (interceptor != null) {
       protocolLayerClient.setRecordInterceptor(interceptor);
     }
@@ -125,7 +127,9 @@ public class HieroAutoConfiguration {
       name = "mirrorNodeSupported",
       havingValue = "true",
       matchIfMissing = true)
-  MirrorNodeClient mirrorNodeClient(final HieroContext hieroContext) {
+  MirrorNodeClient mirrorNodeClient(
+      final HieroContext hieroContext,
+      final org.springframework.beans.factory.ObjectProvider<io.opentelemetry.api.trace.Tracer> tracerProvider) {
     final String mirrorNodeEndpoint;
     final List<String> mirrorNetwork = hieroContext.getClient().getMirrorNetwork();
     if (mirrorNetwork.isEmpty()) {
@@ -160,7 +164,7 @@ public class HieroAutoConfiguration {
           "Error parsing mirrorNodeEndpoint '" + mirrorNodeEndpoint + "'", e);
     }
     RestClient.Builder builder = RestClient.builder().baseUrl(baseUri);
-    return new MirrorNodeClientImpl(builder);
+    return new MirrorNodeClientImpl(builder, tracerProvider.getIfAvailable());
   }
 
   @Bean

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -53,7 +53,7 @@ import org.springframework.web.context.annotation.ApplicationScope;
 
 @AutoConfiguration
 @EnableConfigurationProperties({HieroProperties.class, HieroNetworkProperties.class})
-@Import({MicrometerSupportConfig.class})
+@Import({MicrometerSupportConfig.class, TracingSupportConfig.class})
 public class HieroAutoConfiguration {
 
   private static final Logger log = LoggerFactory.getLogger(HieroAutoConfiguration.class);

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeClientImpl.java
@@ -24,6 +24,8 @@ import org.hiero.base.implementation.MirrorNodeJsonConverter;
 import org.hiero.base.implementation.MirrorNodeRestClient;
 import org.hiero.base.protocol.data.TransactionType;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import io.opentelemetry.api.trace.Tracer;
 import org.springframework.web.client.RestClient;
 
 public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
@@ -42,6 +44,18 @@ public class MirrorNodeClientImpl extends AbstractMirrorNodeClient<JsonNode> {
    * @param restClientBuilder the builder for the REST client that must have the base URL set
    */
   public MirrorNodeClientImpl(final RestClient.Builder restClientBuilder) {
+    this(restClientBuilder, null);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param restClientBuilder the builder for the REST client that must have the base URL set
+   * @param tracer the tracer to use
+   */
+  public MirrorNodeClientImpl(
+      final RestClient.Builder restClientBuilder, @Nullable final Tracer tracer) {
+    super(tracer);
     Objects.requireNonNull(restClientBuilder, "restClientBuilder must not be null");
     mirrorNodeRestClient = new MirrorNodeRestClientImpl(restClientBuilder);
     jsonConverter = new MirrorNodeJsonConverterImpl();

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/TracingSupportConfig.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/TracingSupportConfig.java
@@ -1,0 +1,27 @@
+package org.hiero.spring.implementation;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * OpenTelemetry tracing support for Hiero.
+ */
+@AutoConfiguration
+@ConditionalOnProperty(
+    name = "spring.hiero.tracing.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@ConditionalOnClass(OpenTelemetry.class)
+public class TracingSupportConfig {
+
+  @Bean
+  @NonNull
+  public Tracer hieroTracer(@NonNull final OpenTelemetry openTelemetry) {
+    return openTelemetry.getTracer("org.hiero.enterprise");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
     <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
+    <opentelemetry.version>1.38.0</opentelemetry.version>
   </properties>
 
   <dependencyManagement>
@@ -205,6 +206,13 @@
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service-annotations</artifactId>
         <version>${google.auto.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Fixes #157

## Description
This PR introduces initial OpenTelemetry tracing to hiero-enterprise-java. While we currently have metrics, we’re missing the granular visibility needed to debug transaction latency or Mirror Node timeouts in distributed environments. These changes allow Hiero operations to produce spans that tie into existing OTEL pipelines with minimal setup.

## Key Changes
- Tracing Core: Added a TracingSupport utility in the base module to handle span creation and context propagation consistently.

- Instrumentation: Wrapped ProtocolLayerClientImpl and AbstractMirrorNodeClient to capture the lifecycle of transaction submissions, receipt fetching, and queries.

- Contextual Data: Spans now include tags for transaction IDs, status codes, and operation types for easier filtering in tools like Jaeger or Grafana.

- Integration: Added a TracingSupportConfig for Spring Boot auto-configuration and updated module-info.java to ensure compatibility with JPMS.

Verification
Confirmed the build is stable and dependencies resolve correctly:

```
./mvnw clean compile
```
I'd love to get your thoughts on the span naming convention and whether the current instrumentation covers enough ground for our initial tracing goals.
