### PR TITLE
feat: add ContractLog support to Hiero framework

### DIFF
--- a/hiero-enterprise-base/src/main/java/org/hiero/base/data/Contract.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/data/Contract.java
@@ -35,4 +35,5 @@ public record Contract(
     Objects.requireNonNull(fromTimestamp, "fromTimestamp must not be null");
     Objects.requireNonNull(toTimestamp, "toTimestamp must not be null");
   }
+
 }

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/data/ContractLog.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/data/ContractLog.java
@@ -1,0 +1,24 @@
+package org.hiero.base.data;
+
+import com.hedera.hashgraph.sdk.ContractId;
+import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+
+/** Represents a single log entry emitted by a smart contract on the Hiero network. */
+public record ContractLog(
+    @NonNull ContractId contractId,
+    @NonNull String transactionHash,
+    long blockNumber,
+    int logIndex,
+    @NonNull List<String> topics,
+    @NonNull String data,
+    @NonNull String timestamp) {
+  public ContractLog {
+    Objects.requireNonNull(contractId, "contractId must not be null");
+    Objects.requireNonNull(transactionHash, "transactionHash must not be null");
+    Objects.requireNonNull(topics, "topics must not be null");
+    Objects.requireNonNull(data, "data must not be null");
+    Objects.requireNonNull(timestamp, "timestamp must not be null");
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/AbstractMirrorNodeClient.java
@@ -11,6 +11,7 @@ import org.hiero.base.HieroException;
 import org.hiero.base.data.AccountInfo;
 import org.hiero.base.data.Block;
 import org.hiero.base.data.Contract;
+import org.hiero.base.data.ContractLog;
 import org.hiero.base.data.ExchangeRates;
 import org.hiero.base.data.NetworkFee;
 import org.hiero.base.data.NetworkStake;
@@ -118,6 +119,14 @@ public abstract class AbstractMirrorNodeClient<JSON> implements MirrorNodeClient
     Objects.requireNonNull(contractId, "contractId must not be null");
     final JSON json = getRestClient().queryContractById(contractId);
     return getJsonConverter().toContract(json);
+  }
+
+  @Override
+  public @NonNull Page<ContractLog> queryContractLogs(@NonNull final ContractId contractId)
+      throws HieroException {
+    Objects.requireNonNull(contractId, "contractId must not be null");
+    final JSON json = getRestClient().queryContractLogs(contractId);
+    return getJsonConverter().toContractLogPage(json);
   }
 
   @Override

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ContractLogRepositoryImpl.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/ContractLogRepositoryImpl.java
@@ -1,0 +1,33 @@
+package org.hiero.base.implementation;
+
+import com.hedera.hashgraph.sdk.ContractId;
+import java.util.Objects;
+import org.hiero.base.HieroException;
+import org.hiero.base.data.ContractLog;
+import org.hiero.base.data.Page;
+import org.hiero.base.mirrornode.ContractLogRepository;
+import org.hiero.base.mirrornode.MirrorNodeClient;
+import org.jspecify.annotations.NonNull;
+
+/** Implementation of ContractLogRepository that uses MirrorNodeClient to query contract logs. */
+public class ContractLogRepositoryImpl implements ContractLogRepository {
+
+  private final MirrorNodeClient mirrorNodeClient;
+
+  /**
+   * Creates a new ContractLogRepositoryImpl with the given MirrorNodeClient.
+   *
+   * @param mirrorNodeClient the mirror node client to use for queries
+   */
+  public ContractLogRepositoryImpl(@NonNull final MirrorNodeClient mirrorNodeClient) {
+    this.mirrorNodeClient =
+        Objects.requireNonNull(mirrorNodeClient, "mirrorNodeClient must not be null");
+  }
+
+  @NonNull
+  @Override
+  public Page<ContractLog> findByContractId(@NonNull final ContractId contractId)
+      throws HieroException {
+    return mirrorNodeClient.queryContractLogs(contractId);
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeJsonConverter.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeJsonConverter.java
@@ -6,6 +6,7 @@ import org.hiero.base.data.AccountInfo;
 import org.hiero.base.data.Balance;
 import org.hiero.base.data.Block;
 import org.hiero.base.data.Contract;
+import org.hiero.base.data.ContractLog;
 import org.hiero.base.data.ExchangeRates;
 import org.hiero.base.data.NetworkFee;
 import org.hiero.base.data.NetworkStake;
@@ -55,6 +56,10 @@ public interface MirrorNodeJsonConverter<JSON> {
   @NonNull Page<Contract> toContractPage(@NonNull JSON json);
 
   @NonNull List<Contract> toContracts(@NonNull JSON json);
+
+  @NonNull Page<ContractLog> toContractLogPage(@NonNull JSON json);
+
+  @NonNull List<ContractLog> toContractLogs(@NonNull JSON json);
 
   @NonNull Optional<Block> toBlock(@NonNull JSON json);
 

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/implementation/MirrorNodeRestClient.java
@@ -81,6 +81,12 @@ public interface MirrorNodeRestClient<JSON> {
     return doGetCall("/api/v1/contracts/" + contractId);
   }
 
+  @NonNull
+  default JSON queryContractLogs(@NonNull final ContractId contractId) throws HieroException {
+    Objects.requireNonNull(contractId, "contractId must not be null");
+    return doGetCall("/api/v1/contracts/" + contractId + "/logs");
+  }
+
   /**
    * Queries a block by its identifier (number or hash).
    *

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/ContractLogRepository.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/ContractLogRepository.java
@@ -1,0 +1,37 @@
+package org.hiero.base.mirrornode;
+
+import com.hedera.hashgraph.sdk.ContractId;
+import java.util.Objects;
+import org.hiero.base.HieroException;
+import org.hiero.base.data.ContractLog;
+import org.hiero.base.data.Page;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Interface for querying contract event logs from the Hiero Mirror Node. This interface provides
+ * methods for retrieving logs emitted by smart contracts.
+ */
+public interface ContractLogRepository {
+
+  /**
+   * Return all logs emitted by the given contract.
+   *
+   * @param contractId id of the contract
+   * @return first page of contract logs
+   * @throws HieroException if the search fails
+   */
+  @NonNull Page<ContractLog> findByContractId(@NonNull ContractId contractId) throws HieroException;
+
+  /**
+   * Return all logs emitted by the given contract.
+   *
+   * @param contractId id of the contract as a string
+   * @return first page of contract logs
+   * @throws HieroException if the search fails
+   */
+  @NonNull
+  default Page<ContractLog> findByContractId(@NonNull String contractId) throws HieroException {
+    Objects.requireNonNull(contractId, "contractId must not be null");
+    return findByContractId(ContractId.fromString(contractId));
+  }
+}

--- a/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
+++ b/hiero-enterprise-base/src/main/java/org/hiero/base/mirrornode/MirrorNodeClient.java
@@ -13,6 +13,7 @@ import org.hiero.base.data.Balance;
 import org.hiero.base.data.BalanceModification;
 import org.hiero.base.data.Block;
 import org.hiero.base.data.Contract;
+import org.hiero.base.data.ContractLog;
 import org.hiero.base.data.ExchangeRates;
 import org.hiero.base.data.NetworkFee;
 import org.hiero.base.data.NetworkStake;
@@ -471,6 +472,29 @@ public interface MirrorNodeClient {
   default Optional<Contract> queryContractById(@NonNull String contractId) throws HieroException {
     Objects.requireNonNull(contractId, "contractId must not be null");
     return queryContractById(ContractId.fromString(contractId));
+  }
+
+  /**
+   * Queries the event logs emitted by a contract.
+   *
+   * @param contractId the contract ID
+   * @return a page of contract logs
+   * @throws HieroException if an error occurs
+   */
+  @NonNull Page<ContractLog> queryContractLogs(@NonNull ContractId contractId)
+      throws HieroException;
+
+  /**
+   * Queries the event logs emitted by a contract.
+   *
+   * @param contractId the contract ID as a string
+   * @return a page of contract logs
+   * @throws HieroException if an error occurs
+   */
+  @NonNull
+  default Page<ContractLog> queryContractLogs(@NonNull String contractId) throws HieroException {
+    Objects.requireNonNull(contractId, "contractId must not be null");
+    return queryContractLogs(ContractId.fromString(contractId));
   }
 
   /**

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/ClientProvider.java
@@ -16,6 +16,7 @@ import org.hiero.base.config.HieroConfig;
 import org.hiero.base.implementation.AccountClientImpl;
 import org.hiero.base.implementation.AccountRepositoryImpl;
 import org.hiero.base.implementation.BlockRepositoryImpl;
+import org.hiero.base.implementation.ContractLogRepositoryImpl;
 import org.hiero.base.implementation.ContractRepositoryImpl;
 import org.hiero.base.implementation.FileClientImpl;
 import org.hiero.base.implementation.FungibleTokenClientImpl;
@@ -31,6 +32,7 @@ import org.hiero.base.implementation.TopicRepositoryImpl;
 import org.hiero.base.implementation.TransactionRepositoryImpl;
 import org.hiero.base.mirrornode.AccountRepository;
 import org.hiero.base.mirrornode.BlockRepository;
+import org.hiero.base.mirrornode.ContractLogRepository;
 import org.hiero.base.mirrornode.ContractRepository;
 import org.hiero.base.mirrornode.MirrorNodeClient;
 import org.hiero.base.mirrornode.NetworkRepository;
@@ -200,6 +202,14 @@ public class ClientProvider {
   @ApplicationScoped
   ContractRepository createContractRepository(@NonNull final MirrorNodeClient mirrorNodeClient) {
     return new ContractRepositoryImpl(mirrorNodeClient);
+  }
+
+  @NonNull
+  @Produces
+  @ApplicationScoped
+  ContractLogRepository createContractLogRepository(
+      @NonNull final MirrorNodeClient mirrorNodeClient) {
+    return new ContractLogRepositoryImpl(mirrorNodeClient);
   }
 
   @NonNull

--- a/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/org/hiero/microprofile/implementation/MirrorNodeJsonConverterImpl.java
@@ -26,6 +26,7 @@ import org.hiero.base.data.Balance;
 import org.hiero.base.data.Block;
 import org.hiero.base.data.ChunkInfo;
 import org.hiero.base.data.Contract;
+import org.hiero.base.data.ContractLog;
 import org.hiero.base.data.CustomFee;
 import org.hiero.base.data.ExchangeRate;
 import org.hiero.base.data.ExchangeRates;
@@ -773,6 +774,71 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
       final long decimals = jsonObject.getJsonNumber("decimals").longValue();
 
       return Optional.of(new Balance(account, balance, decimals));
+    } catch (final Exception e) {
+      throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
+    }
+  }
+
+  // ContractLog-related methods
+
+  @Override
+  public @NonNull Page<ContractLog> toContractLogPage(@NonNull JsonObject jsonObject) {
+    Objects.requireNonNull(jsonObject, "jsonObject must not be null");
+    if (jsonObject.isEmpty()) {
+      return new SinglePage<>(List.of());
+    }
+
+    try {
+      final List<ContractLog> logs = toContractLogs(jsonObject);
+      return new SinglePage<>(logs);
+    } catch (final Exception e) {
+      throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
+    }
+  }
+
+  @Override
+  public @NonNull List<ContractLog> toContractLogs(@NonNull JsonObject jsonObject) {
+    Objects.requireNonNull(jsonObject, "jsonObject must not be null");
+    if (!jsonObject.containsKey("logs")) {
+      return List.of();
+    }
+    final JsonArray logsArray = jsonObject.getJsonArray("logs");
+    if (logsArray == null) {
+      throw new IllegalArgumentException("No logs array in JSON");
+    }
+    final Spliterator<JsonValue> spliterator =
+        Spliterators.spliteratorUnknownSize(logsArray.iterator(), Spliterator.ORDERED);
+    return StreamSupport.stream(spliterator, false)
+        .map(n -> toContractLog(n.asJsonObject()))
+        .filter(optional -> optional.isPresent())
+        .map(optional -> optional.get())
+        .toList();
+  }
+
+  private Optional<ContractLog> toContractLog(JsonObject jsonObject) {
+    Objects.requireNonNull(jsonObject, "jsonObject must not be null");
+    if (jsonObject.isEmpty()) {
+      return Optional.empty();
+    }
+
+    try {
+      final ContractId contractId = ContractId.fromString(jsonObject.getString("contract_id"));
+      final String transactionHash = jsonObject.getString("transaction_hash");
+      final long blockNumber = jsonObject.getJsonNumber("block_number").longValue();
+      final int logIndex = jsonObject.getInt("index");
+      final JsonArray topicsArray = jsonObject.getJsonArray("topics");
+      final List<String> topics =
+          StreamSupport.stream(
+                  Spliterators.spliteratorUnknownSize(topicsArray.iterator(), Spliterator.ORDERED),
+                  false)
+              .map(t -> t.toString().replaceAll("^\"|\"$", ""))
+              .toList();
+      final String data = jsonObject.getString("data");
+      final String timestamp = jsonObject.getString("timestamp");
+
+      return Optional.of(
+          new ContractLog(contractId, transactionHash, blockNumber, logIndex, topics, data,
+              timestamp));
     } catch (final Exception e) {
       throw new IllegalStateException("Can not parse JSON: " + jsonObject, e);
     }

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -15,6 +15,7 @@ import org.hiero.base.config.HieroConfig;
 import org.hiero.base.implementation.AccountClientImpl;
 import org.hiero.base.implementation.AccountRepositoryImpl;
 import org.hiero.base.implementation.BlockRepositoryImpl;
+import org.hiero.base.implementation.ContractLogRepositoryImpl;
 import org.hiero.base.implementation.ContractRepositoryImpl;
 import org.hiero.base.implementation.FileClientImpl;
 import org.hiero.base.implementation.FungibleTokenClientImpl;
@@ -31,6 +32,7 @@ import org.hiero.base.implementation.TransactionRepositoryImpl;
 import org.hiero.base.interceptors.ReceiveRecordInterceptor;
 import org.hiero.base.mirrornode.AccountRepository;
 import org.hiero.base.mirrornode.BlockRepository;
+import org.hiero.base.mirrornode.ContractLogRepository;
 import org.hiero.base.mirrornode.ContractRepository;
 import org.hiero.base.mirrornode.MirrorNodeClient;
 import org.hiero.base.mirrornode.NetworkRepository;
@@ -181,6 +183,16 @@ public class HieroAutoConfiguration {
       matchIfMissing = true)
   ContractRepository contractRepository(final MirrorNodeClient mirrorNodeClient) {
     return new ContractRepositoryImpl(mirrorNodeClient);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "spring.hiero",
+      name = "mirrorNodeSupported",
+      havingValue = "true",
+      matchIfMissing = true)
+  ContractLogRepository contractLogRepository(final MirrorNodeClient mirrorNodeClient) {
+    return new ContractLogRepositoryImpl(mirrorNodeClient);
   }
 
   @Bean

--- a/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
+++ b/hiero-enterprise-spring/src/main/java/org/hiero/spring/implementation/MirrorNodeJsonConverterImpl.java
@@ -27,6 +27,7 @@ import org.hiero.base.data.Balance;
 import org.hiero.base.data.Block;
 import org.hiero.base.data.ChunkInfo;
 import org.hiero.base.data.Contract;
+import org.hiero.base.data.ContractLog;
 import org.hiero.base.data.CustomFee;
 import org.hiero.base.data.ExchangeRate;
 import org.hiero.base.data.ExchangeRates;
@@ -877,6 +878,62 @@ public class MirrorNodeJsonConverterImpl implements MirrorNodeJsonConverter<Json
           throw new IllegalArgumentException(
               "Unsupported protobuf key type: " + protoKey.getKeyCase());
     };
+  }
+
+  @Override
+  public @NonNull Page<ContractLog> toContractLogPage(@NonNull JsonNode node) {
+    Objects.requireNonNull(node, "jsonNode must not be null");
+    if (node.isNull() || node.isEmpty()) {
+      return new SinglePage<>(List.of());
+    }
+
+    try {
+      final List<ContractLog> logs = toContractLogs(node);
+      return new SinglePage<>(logs);
+    } catch (final Exception e) {
+      throw new JsonParseException(node, e);
+    }
+  }
+
+  @Override
+  public @NonNull List<ContractLog> toContractLogs(@NonNull JsonNode node) {
+    Objects.requireNonNull(node, "jsonNode must not be null");
+    if (!node.has("logs")) {
+      return List.of();
+    }
+    final JsonNode logsNode = node.get("logs");
+    if (!logsNode.isArray()) {
+      throw new IllegalArgumentException("Logs node is not an array: " + logsNode);
+    }
+    return jsonArrayToStream(logsNode)
+        .map(n -> toContractLog(n))
+        .filter(optional -> optional.isPresent())
+        .map(optional -> optional.get())
+        .toList();
+  }
+
+  private Optional<ContractLog> toContractLog(JsonNode node) {
+    Objects.requireNonNull(node, "jsonNode must not be null");
+    if (node.isNull() || node.isEmpty()) {
+      return Optional.empty();
+    }
+
+    try {
+      final ContractId contractId = ContractId.fromString(node.get("contract_id").asText());
+      final String transactionHash = node.get("transaction_hash").asText();
+      final long blockNumber = node.get("block_number").asLong();
+      final int logIndex = node.get("index").asInt();
+      final List<String> topics =
+          jsonArrayToStream(node.get("topics")).map(t -> t.asText()).toList();
+      final String data = node.get("data").asText();
+      final String timestamp = node.get("timestamp").asText();
+
+      return Optional.of(
+          new ContractLog(contractId, transactionHash, blockNumber, logIndex, topics, data,
+              timestamp));
+    } catch (final Exception e) {
+      throw new JsonParseException(node, e);
+    }
   }
 
   @Override


### PR DESCRIPTION
This commit introduces the ContractLog data model and its associated repository and implementation for querying contract logs from the Hiero Mirror Node. It includes updates to the MirrorNodeClient and JSON converters to handle contract log data, ensuring robust integration across the framework.

Added ContractLog class to represent log entries.
Implemented ContractLogRepository and ContractLogRepositoryImpl for log retrieval.
Updated MirrorNodeClient and MirrorNodeJsonConverter to support contract log queries.
Integrated ContractLog handling in ClientProvider for CDI and Spring configurations.
Description:
Summary

Add ContractLog data record to represent smart contract event log entries (contract ID, transaction hash, block number, log index, topics, data, timestamp)
Add ContractLogRepository interface with findByContractId methods (by ContractId and by string)
Add queryContractLogs to MirrorNodeClient and MirrorNodeRestClient (calls /api/v1/contracts/{id}/logs)
Add ContractLogRepositoryImpl backed by MirrorNodeClient
Implement toContractLogPage / toContractLogs in both Spring and MicroProfile MirrorNodeJsonConverterImpl
Register ContractLogRepository as a CDI bean (MicroProfile) and as a Spring @bean (Spring auto-configuration)
Test plan

Verify ContractLogRepository bean is available for injection in both Spring and MicroProfile contexts
Call findByContractId with a known contract and confirm logs are returned with correct fields (contract ID, hash, block number, log index, topics, data, timestamp)
Verify empty response ({} or missing logs key) returns an empty page without error
Verify null inputs throw NullPointerException with descriptive messages
Confirm the mirror node REST endpoint /api/v1/contracts/{id}/logs is called correctly
Fixes #191 