### PR TITLE
fix: Override and force `bouncycastle` to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <microprofile.version>7.1</microprofile.version>
     <quarkus.version>3.17.2</quarkus.version>
     <google.auto.version>1.1.1</google.auto.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <jboss-logging.version>3.6.3.Final</jboss-logging.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -69,6 +70,16 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
**Description**:
This PR fixes a security vulnerability issue cause by `org.bouncycastle` being downgraded to`1.79`.
 https://github.com/hiero-ledger/hiero-enterprise-java/security/code-scanning/13 

### Changes Made
- Explicitly add `bcprov-jdk18on` and `bcpkix-jdk18on` to root pom

**Related issue(s)**:

Fixes #203

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
