### PR TITLE
fix: JReleaser signing configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,15 @@ jobs:
           cache: maven
 
       - name: Import GPG key
-        run: |
-          echo "${{ secrets.GPG_KEY_CONTENTS }}" | gpg --batch --import
-          mkdir -p ~/.gnupg
-          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
-          echo "use-agent" >> ~/.gnupg/gpg.conf
+        id: gpg_key
+        uses: step-security/ghaction-import-gpg@c0b4a334b9b72bfaaebec86ef022a78a5b17f828 # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
 
       - name: Verify POM Version
         run: |
@@ -87,7 +91,6 @@ jobs:
       - name: Publish with JReleaser
         run: ./mvnw -B -Ppublication jreleaser:full-release -N
         env:
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_KEY_CONTENTS }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/jreleaser.toml
+++ b/jreleaser.toml
@@ -1,6 +1,7 @@
 [signing.pgp]
 active = "ALWAYS"
 armored = true
+mode = "COMMAND"
 
 [deploy.maven.mavenCentral.release-deploy]
 active = "RELEASE"

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
     <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
-    <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
+    <jreleaser-maven-plugin.version>1.24.0</jreleaser-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
     <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
   </properties>


### PR DESCRIPTION
**Description**:
This PR fixes jreleaser ci failures.

**Changes Made**
- Update jreleaser to use `COMMAND` mode for `pgp.signing`.
- Update `Import the GPG key` using `ghaction-import-gpg`.
- Bump version for jreleaser plugin to `1.24.0`

**Related issue(s)**:

Fixes #219

**Notes for reviewer**:
- The current release ci jreleaser toml use in-memory signing, which required additional key configuration for public key and resulted in validation errors during run

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
